### PR TITLE
Download Metal API spec from api.equinix.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,7 @@
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-# https://github.com/OpenAPITools/openapi-generator-cli
-
-SPEC_BASE_URL:=https://api.packet.net/api-docs-test
+SPEC_BASE_URL:=https://api.equinix.com/metal/v1/api-docs
 SPEC_ROOT_FILE:=openapi3.yaml
 SPEC_FETCHED_DIR=spec/oas3.fetched
 SPEC_PATCH_DIR=patches/spec.fetched.json

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/equinix-labs/metal-go
 
 go 1.19
 
-require github.com/stretchr/testify v1.8.1
+require github.com/stretchr/testify v1.8.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/spec/oas3.combined/.openapi-generator/FILES
+++ b/spec/oas3.combined/.openapi-generator/FILES
@@ -1,3 +1,2 @@
-.openapi-generator-ignore
 README.md
 openapi3.yaml


### PR DESCRIPTION
**TL;DR:** The `script/download_spec.sh` script now resolves file paths from `$refs` before downloading files.  This is to work around an issue between the version of `wget` that is included by default on `mikefarah/yq` images and Akamai. 

When a request URL contains `/./` or `/../`, that version of `wget` does _something_ (doesn't support verbose logging, so I don't know exactly what) that Akamai doesn't like, resulting in `403` responses.  This doesn't seem to be an Akamai issue _per se_; installing `curl` or GNU `wget` on the container resolves the 403s.  My best guess based on testing is that BusyBox `wget` is URL-encoding the `/./` and `/../` and Akamai doesn't like that.  Resolving `/./` and `/../` in paths before following `$refs` eliminates the issue.