### PR TITLE
Update output definition for sync job

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
     - name: Install Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
GitHub Actions has changed how outputs are defined for a job:

https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

The old way of defining outputs is deprecated and will break in May 2023; this updates the sync job so it doesn't break when that happens.