### PR TITLE
Fix sync job for split yaml spec

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Sync
       run: |
         make # pull fetch patch gen mod test
-        git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.json
+        git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' spec/**/*.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' metal api docs README.md
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PACKAGE_MAJOR=v1
 CRI=docker # nerdctl
 
 OPENAPI_GENERATOR=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/local ${OPENAPI_IMAGE}
-SPEC_FETCHER=${CRI} run --rm -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
+SPEC_FETCHER=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 GOLANGCI_LINT=golangci-lint
 
 all: pull fetch patch combine-spec clean gen mod docs move-other patch-post fmt test stage


### PR DESCRIPTION
The sync GitHub Action was failing with a permissions error because the `fetch` task in the Makefile did not specify a user.  In addition, the command to commit the updated spec was outdated; it was still looking for JSON files, but we now download the split spec in YAML format.