### PR TITLE
[WIP] feat: Add API service to load an Href

### DIFF
--- a/examples/devices/go.mod
+++ b/examples/devices/go.mod
@@ -1,0 +1,7 @@
+module github.com/equinix-labs/metal-go/examples/plans
+
+go 1.16
+
+require github.com/equinix-labs/metal-go v0.1.1-0.20220706151426-4a8e1963e004
+
+replace github.com/equinix-labs/metal-go => ../..

--- a/examples/devices/go.sum
+++ b/examples/devices/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/devices/main.go
+++ b/examples/devices/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	metal "github.com/equinix-labs/metal-go/metal/v1"
+)
+
+func main() {
+	var deviceId string
+	flag.StringVar(&deviceId, "deviceId", "", "")
+	flag.Parse()
+
+	include := []string{}
+	exclude := []string{}
+	configuration := metal.NewConfiguration()
+	configuration.AddDefaultHeader("X-Auth-Token", os.Getenv("METAL_AUTH_TOKEN"))
+	api_client := metal.NewAPIClient(configuration)
+	device, r, err := api_client.DevicesApi.FindDeviceById(context.Background(), deviceId).Include(include).Exclude(exclude).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DevicesApi.FindDeviceById``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	} else {
+		fmt.Printf("FindDeviceById, Device ID %v, project ID %v", *device.Id, device.Project.Id)
+
+		r, err = api_client.HrefApi.FindByHref(context.Background(), device.Project).Execute()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error when calling `api_client.FindByHref``: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+		} else {
+			fmt.Printf("FindByHref, Device ID %v, project ID %v", *device.Id, *device.Project.Id)
+		}
+	}
+}

--- a/metal/v1/api_href.go
+++ b/metal/v1/api_href.go
@@ -1,0 +1,92 @@
+package v1
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type HrefApiService service
+
+type href interface {
+	GetHref() string
+}
+
+type HrefRequest struct {
+	ctx        context.Context
+	ApiService *HrefApiService
+	model      href
+	include    *[]string
+	exclude    *[]string
+}
+
+// Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects.
+func (r HrefRequest) Include(include []string) HrefRequest {
+	r.include = &include
+	return r
+}
+
+// Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects.
+func (r HrefRequest) Exclude(exclude []string) HrefRequest {
+	r.exclude = &exclude
+	return r
+}
+
+func (r HrefRequest) Execute() (*http.Response, error) {
+	return r.ApiService.FindByHrefExecute(r)
+}
+
+func (a *HrefApiService) FindByHref(ctx context.Context, model href) HrefRequest {
+	return HrefRequest{
+		ApiService: a,
+		ctx:        ctx,
+		model:      model,
+	}
+}
+
+func (a *HrefApiService) FindByHrefExecute(r HrefRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodGet
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+	localVarPath := localBasePath + strings.TrimPrefix(r.model.GetHref(), "/metal/v1")
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if r.include != nil {
+		parameterAddToQuery(localVarQueryParams, "include", r.include, "csv")
+	}
+
+	if r.exclude != nil {
+		parameterAddToQuery(localVarQueryParams, "exclude", r.exclude, "csv")
+	}
+
+	request, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := a.client.callAPI(request)
+	if err != nil {
+		return response, err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return response, err
+	}
+
+	a.client.decode(r.model, body, response.Header.Get("Content-Type"))
+
+	return response, nil
+}

--- a/metal/v1/client.go
+++ b/metal/v1/client.go
@@ -67,6 +67,8 @@ type APIClient struct {
 
 	HardwareReservationsApi *HardwareReservationsApiService
 
+	HrefApi *HrefApiService
+
 	IPAddressesApi *IPAddressesApiService
 
 	IncidentsApi *IncidentsApiService
@@ -151,6 +153,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	c.EventsApi = (*EventsApiService)(&c.common)
 	c.FacilitiesApi = (*FacilitiesApiService)(&c.common)
 	c.HardwareReservationsApi = (*HardwareReservationsApiService)(&c.common)
+	c.HrefApi = (*HrefApiService)(&c.common)
 	c.IPAddressesApi = (*IPAddressesApiService)(&c.common)
 	c.IncidentsApi = (*IncidentsApiService)(&c.common)
 	c.InterconnectionsApi = (*InterconnectionsApiService)(&c.common)

--- a/patches/post/20230224-add-href-service.patch
+++ b/patches/post/20230224-add-href-service.patch
@@ -1,0 +1,135 @@
+diff --git a/metal/v1/api_href.go b/metal/v1/api_href.go
+new file mode 100644
+index 0000000..10eeb80
+--- /dev/null
++++ b/metal/v1/api_href.go
+@@ -0,0 +1,92 @@
++package v1
++
++import (
++	"context"
++	"io/ioutil"
++	"net/http"
++	"net/url"
++	"strings"
++)
++
++type HrefApiService service
++
++type href interface {
++	GetHref() string
++}
++
++type HrefRequest struct {
++	ctx        context.Context
++	ApiService *HrefApiService
++	model      href
++	include    *[]string
++	exclude    *[]string
++}
++
++// Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects.
++func (r HrefRequest) Include(include []string) HrefRequest {
++	r.include = &include
++	return r
++}
++
++// Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects.
++func (r HrefRequest) Exclude(exclude []string) HrefRequest {
++	r.exclude = &exclude
++	return r
++}
++
++func (r HrefRequest) Execute() (*http.Response, error) {
++	return r.ApiService.FindByHrefExecute(r)
++}
++
++func (a *HrefApiService) FindByHref(ctx context.Context, model href) HrefRequest {
++	return HrefRequest{
++		ApiService: a,
++		ctx:        ctx,
++		model:      model,
++	}
++}
++
++func (a *HrefApiService) FindByHrefExecute(r HrefRequest) (*http.Response, error) {
++	var (
++		localVarHTTPMethod = http.MethodGet
++		localVarPostBody   interface{}
++		formFiles          []formFile
++	)
++
++	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "")
++	if err != nil {
++		return nil, &GenericOpenAPIError{error: err.Error()}
++	}
++	localVarPath := localBasePath + strings.TrimPrefix(r.model.GetHref(), "/metal/v1")
++
++	localVarHeaderParams := make(map[string]string)
++	localVarQueryParams := url.Values{}
++	localVarFormParams := url.Values{}
++
++	if r.include != nil {
++		parameterAddToQuery(localVarQueryParams, "include", r.include, "csv")
++	}
++
++	if r.exclude != nil {
++		parameterAddToQuery(localVarQueryParams, "exclude", r.exclude, "csv")
++	}
++
++	request, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
++	if err != nil {
++		return nil, err
++	}
++
++	response, err := a.client.callAPI(request)
++	if err != nil {
++		return response, err
++	}
++
++	body, err := ioutil.ReadAll(response.Body)
++	if err != nil {
++		return response, err
++	}
++
++	a.client.decode(r.model, body, response.Header.Get("Content-Type"))
++
++	return response, nil
++}
+diff --git a/metal/v1/client.go b/metal/v1/client.go
+index 43da440..3b63c6a 100644
+--- a/metal/v1/client.go
++++ b/metal/v1/client.go
+@@ -64,14 +64,16 @@ type APIClient struct {
+ 
+ 	EventsApi *EventsApiService
+ 
+ 	FacilitiesApi *FacilitiesApiService
+ 
+ 	HardwareReservationsApi *HardwareReservationsApiService
+ 
++	HrefApi *HrefApiService
++
+ 	IPAddressesApi *IPAddressesApiService
+ 
+ 	IncidentsApi *IncidentsApiService
+ 
+ 	InterconnectionsApi *InterconnectionsApiService
+ 
+ 	InvitationsApi *InvitationsApiService
+@@ -146,14 +148,15 @@ func NewAPIClient(cfg *Configuration) *APIClient {
+ 	c.BatchesApi = (*BatchesApiService)(&c.common)
+ 	c.CapacityApi = (*CapacityApiService)(&c.common)
+ 	c.DevicesApi = (*DevicesApiService)(&c.common)
+ 	c.EmailsApi = (*EmailsApiService)(&c.common)
+ 	c.EventsApi = (*EventsApiService)(&c.common)
+ 	c.FacilitiesApi = (*FacilitiesApiService)(&c.common)
+ 	c.HardwareReservationsApi = (*HardwareReservationsApiService)(&c.common)
++	c.HrefApi = (*HrefApiService)(&c.common)
+ 	c.IPAddressesApi = (*IPAddressesApiService)(&c.common)
+ 	c.IncidentsApi = (*IncidentsApiService)(&c.common)
+ 	c.InterconnectionsApi = (*InterconnectionsApiService)(&c.common)
+ 	c.InvitationsApi = (*InvitationsApiService)(&c.common)
+ 	c.LicensesApi = (*LicensesApiService)(&c.common)
+ 	c.MembershipsApi = (*MembershipsApiService)(&c.common)
+ 	c.MetalGatewaysApi = (*MetalGatewaysApiService)(&c.common)


### PR DESCRIPTION
This PR demonstrates a way to enable users to hydrate hrefs that come back from the API without using `include` parameters.  It's not clear that we actually _want_ to provide a way to do this, but it's at least a fun exploration of how the generated Go client is wired up.

This hooks into the generated `client` code in order to read the `href` path from an object returned by the API, turn that `href` into a full request URL, send that request to the API, and unmarshall the JSON response as the appropriate model type.