### PR TITLE
Generate OpenAPI spec-compliant code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ gen:
 	${OPENAPI_GENERATOR} generate -g go \
 		--package-name ${PACKAGE_MAJOR} \
 		-p isGoSubmodule=true \
+		-p disallowAdditionalPropertiesIfNotPresent=false \
 		--model-package types \
 		--api-package models \
 		--git-user-id ${GIT_ORG} \

--- a/metal/v1/model_activate_hardware_reservation_request.go
+++ b/metal/v1/model_activate_hardware_reservation_request.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &ActivateHardwareReservationRequest{}
 
 // ActivateHardwareReservationRequest struct for ActivateHardwareReservationRequest
 type ActivateHardwareReservationRequest struct {
-	Description *string `json:"description,omitempty"`
+	Description          *string `json:"description,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ActivateHardwareReservationRequest ActivateHardwareReservationRequest
 
 // NewActivateHardwareReservationRequest instantiates a new ActivateHardwareReservationRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o ActivateHardwareReservationRequest) ToMap() (map[string]interface{}, err
 	if !isNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ActivateHardwareReservationRequest) UnmarshalJSON(bytes []byte) (err error) {
+	varActivateHardwareReservationRequest := _ActivateHardwareReservationRequest{}
+
+	if err = json.Unmarshal(bytes, &varActivateHardwareReservationRequest); err == nil {
+		*o = ActivateHardwareReservationRequest(varActivateHardwareReservationRequest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableActivateHardwareReservationRequest struct {

--- a/metal/v1/model_address.go
+++ b/metal/v1/model_address.go
@@ -20,14 +20,17 @@ var _ MappedNullable = &Address{}
 
 // Address struct for Address
 type Address struct {
-	Address     string       `json:"address"`
-	Address2    *string      `json:"address2,omitempty"`
-	City        *string      `json:"city,omitempty"`
-	Coordinates *Coordinates `json:"coordinates,omitempty"`
-	Country     string       `json:"country"`
-	State       *string      `json:"state,omitempty"`
-	ZipCode     string       `json:"zip_code"`
+	Address              string       `json:"address"`
+	Address2             *string      `json:"address2,omitempty"`
+	City                 *string      `json:"city,omitempty"`
+	Coordinates          *Coordinates `json:"coordinates,omitempty"`
+	Country              string       `json:"country"`
+	State                *string      `json:"state,omitempty"`
+	ZipCode              string       `json:"zip_code"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Address Address
 
 // NewAddress instantiates a new Address object
 // This constructor will assign default values to properties that have it defined,
@@ -274,7 +277,35 @@ func (o Address) ToMap() (map[string]interface{}, error) {
 		toSerialize["state"] = o.State
 	}
 	toSerialize["zip_code"] = o.ZipCode
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Address) UnmarshalJSON(bytes []byte) (err error) {
+	varAddress := _Address{}
+
+	if err = json.Unmarshal(bytes, &varAddress); err == nil {
+		*o = Address(varAddress)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "address2")
+		delete(additionalProperties, "city")
+		delete(additionalProperties, "coordinates")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "zip_code")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAddress struct {

--- a/metal/v1/model_auth_token.go
+++ b/metal/v1/model_auth_token.go
@@ -23,14 +23,17 @@ var _ MappedNullable = &AuthToken{}
 type AuthToken struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// Available only for API keys
-	Description *string           `json:"description,omitempty"`
-	Id          *string           `json:"id,omitempty"`
-	Project     *AuthTokenProject `json:"project,omitempty"`
-	ReadOnly    *bool             `json:"read_only,omitempty"`
-	Token       *string           `json:"token,omitempty"`
-	UpdatedAt   *time.Time        `json:"updated_at,omitempty"`
-	User        *AuthTokenUser    `json:"user,omitempty"`
+	Description          *string           `json:"description,omitempty"`
+	Id                   *string           `json:"id,omitempty"`
+	Project              *AuthTokenProject `json:"project,omitempty"`
+	ReadOnly             *bool             `json:"read_only,omitempty"`
+	Token                *string           `json:"token,omitempty"`
+	UpdatedAt            *time.Time        `json:"updated_at,omitempty"`
+	User                 *AuthTokenUser    `json:"user,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AuthToken AuthToken
 
 // NewAuthToken instantiates a new AuthToken object
 // This constructor will assign default values to properties that have it defined,
@@ -339,7 +342,36 @@ func (o AuthToken) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.User) {
 		toSerialize["user"] = o.User
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AuthToken) UnmarshalJSON(bytes []byte) (err error) {
+	varAuthToken := _AuthToken{}
+
+	if err = json.Unmarshal(bytes, &varAuthToken); err == nil {
+		*o = AuthToken(varAuthToken)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "read_only")
+		delete(additionalProperties, "token")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "user")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAuthToken struct {

--- a/metal/v1/model_auth_token_input.go
+++ b/metal/v1/model_auth_token_input.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &AuthTokenInput{}
 
 // AuthTokenInput struct for AuthTokenInput
 type AuthTokenInput struct {
-	Description *string `json:"description,omitempty"`
-	ReadOnly    *bool   `json:"read_only,omitempty"`
+	Description          *string `json:"description,omitempty"`
+	ReadOnly             *bool   `json:"read_only,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AuthTokenInput AuthTokenInput
 
 // NewAuthTokenInput instantiates a new AuthTokenInput object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o AuthTokenInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.ReadOnly) {
 		toSerialize["read_only"] = o.ReadOnly
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AuthTokenInput) UnmarshalJSON(bytes []byte) (err error) {
+	varAuthTokenInput := _AuthTokenInput{}
+
+	if err = json.Unmarshal(bytes, &varAuthTokenInput); err == nil {
+		*o = AuthTokenInput(varAuthTokenInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "read_only")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAuthTokenInput struct {

--- a/metal/v1/model_auth_token_list.go
+++ b/metal/v1/model_auth_token_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &AuthTokenList{}
 
 // AuthTokenList struct for AuthTokenList
 type AuthTokenList struct {
-	ApiKeys []AuthToken `json:"api_keys,omitempty"`
+	ApiKeys              []AuthToken `json:"api_keys,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AuthTokenList AuthTokenList
 
 // NewAuthTokenList instantiates a new AuthTokenList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o AuthTokenList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.ApiKeys) {
 		toSerialize["api_keys"] = o.ApiKeys
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AuthTokenList) UnmarshalJSON(bytes []byte) (err error) {
+	varAuthTokenList := _AuthTokenList{}
+
+	if err = json.Unmarshal(bytes, &varAuthTokenList); err == nil {
+		*o = AuthTokenList(varAuthTokenList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "api_keys")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAuthTokenList struct {

--- a/metal/v1/model_auth_token_project.go
+++ b/metal/v1/model_auth_token_project.go
@@ -21,23 +21,26 @@ var _ MappedNullable = &AuthTokenProject{}
 
 // AuthTokenProject struct for AuthTokenProject
 type AuthTokenProject struct {
-	BgpConfig     *Href                  `json:"bgp_config,omitempty"`
-	CreatedAt     *time.Time             `json:"created_at,omitempty"`
-	Customdata    map[string]interface{} `json:"customdata,omitempty"`
-	Devices       []Href                 `json:"devices,omitempty"`
-	Href          *string                `json:"href,omitempty"`
-	Id            *string                `json:"id,omitempty"`
-	Invitations   []Href                 `json:"invitations,omitempty"`
-	MaxDevices    map[string]interface{} `json:"max_devices,omitempty"`
-	Members       []Href                 `json:"members,omitempty"`
-	Memberships   []Href                 `json:"memberships,omitempty"`
-	Name          *string                `json:"name,omitempty"`
-	NetworkStatus map[string]interface{} `json:"network_status,omitempty"`
-	PaymentMethod *Href                  `json:"payment_method,omitempty"`
-	SshKeys       []Href                 `json:"ssh_keys,omitempty"`
-	UpdatedAt     *time.Time             `json:"updated_at,omitempty"`
-	Volumes       []Href                 `json:"volumes,omitempty"`
+	BgpConfig            *Href                  `json:"bgp_config,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Devices              []Href                 `json:"devices,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   *string                `json:"id,omitempty"`
+	Invitations          []Href                 `json:"invitations,omitempty"`
+	MaxDevices           map[string]interface{} `json:"max_devices,omitempty"`
+	Members              []Href                 `json:"members,omitempty"`
+	Memberships          []Href                 `json:"memberships,omitempty"`
+	Name                 *string                `json:"name,omitempty"`
+	NetworkStatus        map[string]interface{} `json:"network_status,omitempty"`
+	PaymentMethod        *Href                  `json:"payment_method,omitempty"`
+	SshKeys              []Href                 `json:"ssh_keys,omitempty"`
+	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
+	Volumes              []Href                 `json:"volumes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AuthTokenProject AuthTokenProject
 
 // NewAuthTokenProject instantiates a new AuthTokenProject object
 // This constructor will assign default values to properties that have it defined,
@@ -626,7 +629,44 @@ func (o AuthTokenProject) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AuthTokenProject) UnmarshalJSON(bytes []byte) (err error) {
+	varAuthTokenProject := _AuthTokenProject{}
+
+	if err = json.Unmarshal(bytes, &varAuthTokenProject); err == nil {
+		*o = AuthTokenProject(varAuthTokenProject)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_config")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "devices")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "invitations")
+		delete(additionalProperties, "max_devices")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "memberships")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "network_status")
+		delete(additionalProperties, "payment_method")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "volumes")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAuthTokenProject struct {

--- a/metal/v1/model_auth_token_user.go
+++ b/metal/v1/model_auth_token_user.go
@@ -21,27 +21,30 @@ var _ MappedNullable = &AuthTokenUser{}
 
 // AuthTokenUser struct for AuthTokenUser
 type AuthTokenUser struct {
-	AvatarThumbUrl   *string                `json:"avatar_thumb_url,omitempty"`
-	AvatarUrl        *string                `json:"avatar_url,omitempty"`
-	CreatedAt        *time.Time             `json:"created_at,omitempty"`
-	Customdata       map[string]interface{} `json:"customdata,omitempty"`
-	Email            *string                `json:"email,omitempty"`
-	Emails           []Href                 `json:"emails,omitempty"`
-	FirstName        *string                `json:"first_name,omitempty"`
-	FraudScore       *string                `json:"fraud_score,omitempty"`
-	FullName         *string                `json:"full_name,omitempty"`
-	Href             *string                `json:"href,omitempty"`
-	Id               *string                `json:"id,omitempty"`
-	LastLoginAt      *time.Time             `json:"last_login_at,omitempty"`
-	LastName         *string                `json:"last_name,omitempty"`
-	MaxOrganizations *int32                 `json:"max_organizations,omitempty"`
-	MaxProjects      *int32                 `json:"max_projects,omitempty"`
-	PhoneNumber      *string                `json:"phone_number,omitempty"`
-	ShortId          *string                `json:"short_id,omitempty"`
-	Timezone         *string                `json:"timezone,omitempty"`
-	TwoFactorAuth    *string                `json:"two_factor_auth,omitempty"`
-	UpdatedAt        *time.Time             `json:"updated_at,omitempty"`
+	AvatarThumbUrl       *string                `json:"avatar_thumb_url,omitempty"`
+	AvatarUrl            *string                `json:"avatar_url,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Email                *string                `json:"email,omitempty"`
+	Emails               []Href                 `json:"emails,omitempty"`
+	FirstName            *string                `json:"first_name,omitempty"`
+	FraudScore           *string                `json:"fraud_score,omitempty"`
+	FullName             *string                `json:"full_name,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   *string                `json:"id,omitempty"`
+	LastLoginAt          *time.Time             `json:"last_login_at,omitempty"`
+	LastName             *string                `json:"last_name,omitempty"`
+	MaxOrganizations     *int32                 `json:"max_organizations,omitempty"`
+	MaxProjects          *int32                 `json:"max_projects,omitempty"`
+	PhoneNumber          *string                `json:"phone_number,omitempty"`
+	ShortId              *string                `json:"short_id,omitempty"`
+	Timezone             *string                `json:"timezone,omitempty"`
+	TwoFactorAuth        *string                `json:"two_factor_auth,omitempty"`
+	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AuthTokenUser AuthTokenUser
 
 // NewAuthTokenUser instantiates a new AuthTokenUser object
 // This constructor will assign default values to properties that have it defined,
@@ -770,7 +773,48 @@ func (o AuthTokenUser) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AuthTokenUser) UnmarshalJSON(bytes []byte) (err error) {
+	varAuthTokenUser := _AuthTokenUser{}
+
+	if err = json.Unmarshal(bytes, &varAuthTokenUser); err == nil {
+		*o = AuthTokenUser(varAuthTokenUser)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "avatar_thumb_url")
+		delete(additionalProperties, "avatar_url")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "emails")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "fraud_score")
+		delete(additionalProperties, "full_name")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "last_login_at")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "max_organizations")
+		delete(additionalProperties, "max_projects")
+		delete(additionalProperties, "phone_number")
+		delete(additionalProperties, "short_id")
+		delete(additionalProperties, "timezone")
+		delete(additionalProperties, "two_factor_auth")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAuthTokenUser struct {

--- a/metal/v1/model_batch.go
+++ b/metal/v1/model_batch.go
@@ -21,15 +21,18 @@ var _ MappedNullable = &Batch{}
 
 // Batch struct for Batch
 type Batch struct {
-	CreatedAt     *time.Time `json:"created_at,omitempty"`
-	Devices       []Href     `json:"devices,omitempty"`
-	ErrorMessages []string   `json:"error_messages,omitempty"`
-	Id            *string    `json:"id,omitempty"`
-	Project       *Href      `json:"project,omitempty"`
-	Quantity      *int32     `json:"quantity,omitempty"`
-	State         *string    `json:"state,omitempty"`
-	UpdatedAt     *time.Time `json:"updated_at,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	Devices              []Href     `json:"devices,omitempty"`
+	ErrorMessages        []string   `json:"error_messages,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Project              *Href      `json:"project,omitempty"`
+	Quantity             *int32     `json:"quantity,omitempty"`
+	State                *string    `json:"state,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Batch Batch
 
 // NewBatch instantiates a new Batch object
 // This constructor will assign default values to properties that have it defined,
@@ -338,7 +341,36 @@ func (o Batch) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Batch) UnmarshalJSON(bytes []byte) (err error) {
+	varBatch := _Batch{}
+
+	if err = json.Unmarshal(bytes, &varBatch); err == nil {
+		*o = Batch(varBatch)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "devices")
+		delete(additionalProperties, "error_messages")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBatch struct {

--- a/metal/v1/model_batches_list.go
+++ b/metal/v1/model_batches_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &BatchesList{}
 
 // BatchesList struct for BatchesList
 type BatchesList struct {
-	Batches []Batch `json:"batches,omitempty"`
+	Batches              []Batch `json:"batches,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BatchesList BatchesList
 
 // NewBatchesList instantiates a new BatchesList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o BatchesList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Batches) {
 		toSerialize["batches"] = o.Batches
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BatchesList) UnmarshalJSON(bytes []byte) (err error) {
+	varBatchesList := _BatchesList{}
+
+	if err = json.Unmarshal(bytes, &varBatchesList); err == nil {
+		*o = BatchesList(varBatchesList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "batches")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBatchesList struct {

--- a/metal/v1/model_bgp_config.go
+++ b/metal/v1/model_bgp_config.go
@@ -41,8 +41,11 @@ type BgpConfig struct {
 	// The direct connections between neighboring routers that want to exchange routing information.
 	Sessions []BgpSession `json:"sessions,omitempty"`
 	// Status of the BGP Config. Status \"requested\" is valid only with the \"global\" deployment_type.
-	Status *string `json:"status,omitempty"`
+	Status               *string `json:"status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpConfig BgpConfig
 
 // NewBgpConfig instantiates a new BgpConfig object
 // This constructor will assign default values to properties that have it defined,
@@ -541,7 +544,41 @@ func (o BgpConfig) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpConfig) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpConfig := _BgpConfig{}
+
+	if err = json.Unmarshal(bytes, &varBgpConfig); err == nil {
+		*o = BgpConfig(varBgpConfig)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "asn")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "deployment_type")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "max_prefix")
+		delete(additionalProperties, "md5")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "ranges")
+		delete(additionalProperties, "requested_at")
+		delete(additionalProperties, "route_object")
+		delete(additionalProperties, "sessions")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpConfig struct {

--- a/metal/v1/model_bgp_config_request_input.go
+++ b/metal/v1/model_bgp_config_request_input.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &BgpConfigRequestInput{}
 
 // BgpConfigRequestInput struct for BgpConfigRequestInput
 type BgpConfigRequestInput struct {
-	Asn            int32   `json:"asn"`
-	DeploymentType string  `json:"deployment_type"`
-	Md5            *string `json:"md5,omitempty"`
-	UseCase        *string `json:"use_case,omitempty"`
+	Asn                  int32   `json:"asn"`
+	DeploymentType       string  `json:"deployment_type"`
+	Md5                  *string `json:"md5,omitempty"`
+	UseCase              *string `json:"use_case,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpConfigRequestInput BgpConfigRequestInput
 
 // NewBgpConfigRequestInput instantiates a new BgpConfigRequestInput object
 // This constructor will assign default values to properties that have it defined,
@@ -175,7 +178,32 @@ func (o BgpConfigRequestInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UseCase) {
 		toSerialize["use_case"] = o.UseCase
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpConfigRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpConfigRequestInput := _BgpConfigRequestInput{}
+
+	if err = json.Unmarshal(bytes, &varBgpConfigRequestInput); err == nil {
+		*o = BgpConfigRequestInput(varBgpConfigRequestInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "asn")
+		delete(additionalProperties, "deployment_type")
+		delete(additionalProperties, "md5")
+		delete(additionalProperties, "use_case")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpConfigRequestInput struct {

--- a/metal/v1/model_bgp_dynamic_neighbor.go
+++ b/metal/v1/model_bgp_dynamic_neighbor.go
@@ -26,14 +26,17 @@ type BgpDynamicNeighbor struct {
 	// The ASN of the dynamic BGP neighbor
 	BgpNeighborAsn *int32 `json:"bgp_neighbor_asn,omitempty"`
 	// Network range of the dynamic BGP neighbor in CIDR format
-	BgpNeighborRange *string          `json:"bgp_neighbor_range,omitempty"`
-	MetalGateway     *VrfMetalGateway `json:"metal_gateway,omitempty"`
-	State            *string          `json:"state,omitempty"`
-	Href             *string          `json:"href,omitempty"`
-	CreatedAt        *time.Time       `json:"created_at,omitempty"`
-	CreatedBy        *UserLimited     `json:"created_by,omitempty"`
-	UpdatedAt        *time.Time       `json:"updated_at,omitempty"`
+	BgpNeighborRange     *string          `json:"bgp_neighbor_range,omitempty"`
+	MetalGateway         *VrfMetalGateway `json:"metal_gateway,omitempty"`
+	State                *string          `json:"state,omitempty"`
+	Href                 *string          `json:"href,omitempty"`
+	CreatedAt            *time.Time       `json:"created_at,omitempty"`
+	CreatedBy            *UserLimited     `json:"created_by,omitempty"`
+	UpdatedAt            *time.Time       `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpDynamicNeighbor BgpDynamicNeighbor
 
 // NewBgpDynamicNeighbor instantiates a new BgpDynamicNeighbor object
 // This constructor will assign default values to properties that have it defined,
@@ -367,7 +370,37 @@ func (o BgpDynamicNeighbor) ToMap() (map[string]interface{}, error) {
 		toSerialize["created_by"] = o.CreatedBy
 	}
 	// skip: updated_at is readOnly
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpDynamicNeighbor) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpDynamicNeighbor := _BgpDynamicNeighbor{}
+
+	if err = json.Unmarshal(bytes, &varBgpDynamicNeighbor); err == nil {
+		*o = BgpDynamicNeighbor(varBgpDynamicNeighbor)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "bgp_neighbor_asn")
+		delete(additionalProperties, "bgp_neighbor_range")
+		delete(additionalProperties, "metal_gateway")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "created_by")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpDynamicNeighbor struct {

--- a/metal/v1/model_bgp_dynamic_neighbor_create_input.go
+++ b/metal/v1/model_bgp_dynamic_neighbor_create_input.go
@@ -23,8 +23,11 @@ type BgpDynamicNeighborCreateInput struct {
 	// Network range of the dynamic BGP neighbor in CIDR format
 	BgpNeighborRange *string `json:"bgp_neighbor_range,omitempty"`
 	// The ASN of the dynamic BGP neighbor
-	BgpNeighborAsn *int32 `json:"bgp_neighbor_asn,omitempty"`
+	BgpNeighborAsn       *int32 `json:"bgp_neighbor_asn,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpDynamicNeighborCreateInput BgpDynamicNeighborCreateInput
 
 // NewBgpDynamicNeighborCreateInput instantiates a new BgpDynamicNeighborCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -123,7 +126,30 @@ func (o BgpDynamicNeighborCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.BgpNeighborAsn) {
 		toSerialize["bgp_neighbor_asn"] = o.BgpNeighborAsn
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpDynamicNeighborCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpDynamicNeighborCreateInput := _BgpDynamicNeighborCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varBgpDynamicNeighborCreateInput); err == nil {
+		*o = BgpDynamicNeighborCreateInput(varBgpDynamicNeighborCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_neighbor_range")
+		delete(additionalProperties, "bgp_neighbor_asn")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpDynamicNeighborCreateInput struct {

--- a/metal/v1/model_bgp_dynamic_neighbor_list.go
+++ b/metal/v1/model_bgp_dynamic_neighbor_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &BgpDynamicNeighborList{}
 
 // BgpDynamicNeighborList struct for BgpDynamicNeighborList
 type BgpDynamicNeighborList struct {
-	BgpDynamicNeighbors []BgpDynamicNeighbor `json:"bgp_dynamic_neighbors,omitempty"`
-	Meta                *Meta                `json:"meta,omitempty"`
+	BgpDynamicNeighbors  []BgpDynamicNeighbor `json:"bgp_dynamic_neighbors,omitempty"`
+	Meta                 *Meta                `json:"meta,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpDynamicNeighborList BgpDynamicNeighborList
 
 // NewBgpDynamicNeighborList instantiates a new BgpDynamicNeighborList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o BgpDynamicNeighborList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Meta) {
 		toSerialize["meta"] = o.Meta
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpDynamicNeighborList) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpDynamicNeighborList := _BgpDynamicNeighborList{}
+
+	if err = json.Unmarshal(bytes, &varBgpDynamicNeighborList); err == nil {
+		*o = BgpDynamicNeighborList(varBgpDynamicNeighborList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_dynamic_neighbors")
+		delete(additionalProperties, "meta")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpDynamicNeighborList struct {

--- a/metal/v1/model_bgp_neighbor_data.go
+++ b/metal/v1/model_bgp_neighbor_data.go
@@ -39,8 +39,11 @@ type BgpNeighborData struct {
 	// A list of project subnets
 	RoutesIn []BgpRoute `json:"routes_in,omitempty"`
 	// A list of outgoing routes. Only populated if the BGP session has default route enabled.
-	RoutesOut []BgpRoute `json:"routes_out,omitempty"`
+	RoutesOut            []BgpRoute `json:"routes_out,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpNeighborData BgpNeighborData
 
 // NewBgpNeighborData instantiates a new BgpNeighborData object
 // This constructor will assign default values to properties that have it defined,
@@ -419,7 +422,38 @@ func (o BgpNeighborData) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.RoutesOut) {
 		toSerialize["routes_out"] = o.RoutesOut
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpNeighborData) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpNeighborData := _BgpNeighborData{}
+
+	if err = json.Unmarshal(bytes, &varBgpNeighborData); err == nil {
+		*o = BgpNeighborData(varBgpNeighborData)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "customer_as")
+		delete(additionalProperties, "customer_ip")
+		delete(additionalProperties, "md5_enabled")
+		delete(additionalProperties, "md5_password")
+		delete(additionalProperties, "multihop")
+		delete(additionalProperties, "peer_as")
+		delete(additionalProperties, "peer_ips")
+		delete(additionalProperties, "routes_in")
+		delete(additionalProperties, "routes_out")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpNeighborData struct {

--- a/metal/v1/model_bgp_route.go
+++ b/metal/v1/model_bgp_route.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &BgpRoute{}
 
 // BgpRoute struct for BgpRoute
 type BgpRoute struct {
-	Exact *bool   `json:"exact,omitempty"`
-	Route *string `json:"route,omitempty"`
+	Exact                *bool   `json:"exact,omitempty"`
+	Route                *string `json:"route,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpRoute BgpRoute
 
 // NewBgpRoute instantiates a new BgpRoute object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o BgpRoute) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Route) {
 		toSerialize["route"] = o.Route
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpRoute) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpRoute := _BgpRoute{}
+
+	if err = json.Unmarshal(bytes, &varBgpRoute); err == nil {
+		*o = BgpRoute(varBgpRoute)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "exact")
+		delete(additionalProperties, "route")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpRoute struct {

--- a/metal/v1/model_bgp_session.go
+++ b/metal/v1/model_bgp_session.go
@@ -29,9 +29,12 @@ type BgpSession struct {
 	Id            *string    `json:"id,omitempty"`
 	LearnedRoutes []string   `json:"learned_routes,omitempty"`
 	//  The status of the BGP Session. Multiple status values may be reported when the device is connected to multiple switches, one value per switch. Each status will start with \"unknown\" and progress to \"up\" or \"down\" depending on the connected device. Subsequent \"unknown\" values indicate a problem acquiring status from the switch.
-	Status    *string    `json:"status,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	Status               *string    `json:"status,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpSession BgpSession
 
 // NewBgpSession instantiates a new BgpSession object
 // This constructor will assign default values to properties that have it defined,
@@ -366,7 +369,37 @@ func (o BgpSession) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpSession) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpSession := _BgpSession{}
+
+	if err = json.Unmarshal(bytes, &varBgpSession); err == nil {
+		*o = BgpSession(varBgpSession)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "default_route")
+		delete(additionalProperties, "device")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "learned_routes")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpSession struct {

--- a/metal/v1/model_bgp_session_input.go
+++ b/metal/v1/model_bgp_session_input.go
@@ -23,8 +23,11 @@ type BGPSessionInput struct {
 	// Address family for BGP session.
 	AddressFamily *string `json:"address_family,omitempty"`
 	// Set the default route policy.
-	DefaultRoute *bool `json:"default_route,omitempty"`
+	DefaultRoute         *bool `json:"default_route,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BGPSessionInput BGPSessionInput
 
 // NewBGPSessionInput instantiates a new BGPSessionInput object
 // This constructor will assign default values to properties that have it defined,
@@ -127,7 +130,30 @@ func (o BGPSessionInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.DefaultRoute) {
 		toSerialize["default_route"] = o.DefaultRoute
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BGPSessionInput) UnmarshalJSON(bytes []byte) (err error) {
+	varBGPSessionInput := _BGPSessionInput{}
+
+	if err = json.Unmarshal(bytes, &varBGPSessionInput); err == nil {
+		*o = BGPSessionInput(varBGPSessionInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "default_route")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBGPSessionInput struct {

--- a/metal/v1/model_bgp_session_list.go
+++ b/metal/v1/model_bgp_session_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &BgpSessionList{}
 
 // BgpSessionList struct for BgpSessionList
 type BgpSessionList struct {
-	BgpSessions []BgpSession `json:"bgp_sessions,omitempty"`
+	BgpSessions          []BgpSession `json:"bgp_sessions,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpSessionList BgpSessionList
 
 // NewBgpSessionList instantiates a new BgpSessionList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o BgpSessionList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.BgpSessions) {
 		toSerialize["bgp_sessions"] = o.BgpSessions
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpSessionList) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpSessionList := _BgpSessionList{}
+
+	if err = json.Unmarshal(bytes, &varBgpSessionList); err == nil {
+		*o = BgpSessionList(varBgpSessionList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_sessions")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpSessionList struct {

--- a/metal/v1/model_bgp_session_neighbors.go
+++ b/metal/v1/model_bgp_session_neighbors.go
@@ -21,8 +21,11 @@ var _ MappedNullable = &BgpSessionNeighbors{}
 // BgpSessionNeighbors struct for BgpSessionNeighbors
 type BgpSessionNeighbors struct {
 	// A list of BGP session neighbor data
-	BgpNeighbors []BgpNeighborData `json:"bgp_neighbors,omitempty"`
+	BgpNeighbors         []BgpNeighborData `json:"bgp_neighbors,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BgpSessionNeighbors BgpSessionNeighbors
 
 // NewBgpSessionNeighbors instantiates a new BgpSessionNeighbors object
 // This constructor will assign default values to properties that have it defined,
@@ -86,7 +89,29 @@ func (o BgpSessionNeighbors) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.BgpNeighbors) {
 		toSerialize["bgp_neighbors"] = o.BgpNeighbors
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BgpSessionNeighbors) UnmarshalJSON(bytes []byte) (err error) {
+	varBgpSessionNeighbors := _BgpSessionNeighbors{}
+
+	if err = json.Unmarshal(bytes, &varBgpSessionNeighbors); err == nil {
+		*o = BgpSessionNeighbors(varBgpSessionNeighbors)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_neighbors")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBgpSessionNeighbors struct {

--- a/metal/v1/model_bond_port_data.go
+++ b/metal/v1/model_bond_port_data.go
@@ -23,8 +23,11 @@ type BondPortData struct {
 	// ID of the bonding port
 	Id *string `json:"id,omitempty"`
 	// Name of the port interface for the bond (\"bond0\")
-	Name *string `json:"name,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BondPortData BondPortData
 
 // NewBondPortData instantiates a new BondPortData object
 // This constructor will assign default values to properties that have it defined,
@@ -123,7 +126,30 @@ func (o BondPortData) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BondPortData) UnmarshalJSON(bytes []byte) (err error) {
+	varBondPortData := _BondPortData{}
+
+	if err = json.Unmarshal(bytes, &varBondPortData); err == nil {
+		*o = BondPortData(varBondPortData)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBondPortData struct {

--- a/metal/v1/model_capacity_check_per_facility_info.go
+++ b/metal/v1/model_capacity_check_per_facility_info.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &CapacityCheckPerFacilityInfo{}
 
 // CapacityCheckPerFacilityInfo struct for CapacityCheckPerFacilityInfo
 type CapacityCheckPerFacilityInfo struct {
-	Available *bool   `json:"available,omitempty"`
-	Facility  *string `json:"facility,omitempty"`
-	Plan      *string `json:"plan,omitempty"`
-	Quantity  *string `json:"quantity,omitempty"`
+	Available            *bool   `json:"available,omitempty"`
+	Facility             *string `json:"facility,omitempty"`
+	Plan                 *string `json:"plan,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityCheckPerFacilityInfo CapacityCheckPerFacilityInfo
 
 // NewCapacityCheckPerFacilityInfo instantiates a new CapacityCheckPerFacilityInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o CapacityCheckPerFacilityInfo) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityCheckPerFacilityInfo) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityCheckPerFacilityInfo := _CapacityCheckPerFacilityInfo{}
+
+	if err = json.Unmarshal(bytes, &varCapacityCheckPerFacilityInfo); err == nil {
+		*o = CapacityCheckPerFacilityInfo(varCapacityCheckPerFacilityInfo)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "available")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "quantity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityCheckPerFacilityInfo struct {

--- a/metal/v1/model_capacity_check_per_facility_list.go
+++ b/metal/v1/model_capacity_check_per_facility_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityCheckPerFacilityList{}
 
 // CapacityCheckPerFacilityList struct for CapacityCheckPerFacilityList
 type CapacityCheckPerFacilityList struct {
-	Servers []CapacityCheckPerFacilityInfo `json:"servers,omitempty"`
+	Servers              []CapacityCheckPerFacilityInfo `json:"servers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityCheckPerFacilityList CapacityCheckPerFacilityList
 
 // NewCapacityCheckPerFacilityList instantiates a new CapacityCheckPerFacilityList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityCheckPerFacilityList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Servers) {
 		toSerialize["servers"] = o.Servers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityCheckPerFacilityList) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityCheckPerFacilityList := _CapacityCheckPerFacilityList{}
+
+	if err = json.Unmarshal(bytes, &varCapacityCheckPerFacilityList); err == nil {
+		*o = CapacityCheckPerFacilityList(varCapacityCheckPerFacilityList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "servers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityCheckPerFacilityList struct {

--- a/metal/v1/model_capacity_check_per_metro_info.go
+++ b/metal/v1/model_capacity_check_per_metro_info.go
@@ -27,8 +27,11 @@ type CapacityCheckPerMetroInfo struct {
 	// The plan ID or slug sent to check capacity.
 	Plan *string `json:"plan,omitempty"`
 	// The number of servers sent to check capacity.
-	Quantity *string `json:"quantity,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityCheckPerMetroInfo CapacityCheckPerMetroInfo
 
 // NewCapacityCheckPerMetroInfo instantiates a new CapacityCheckPerMetroInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -197,7 +200,32 @@ func (o CapacityCheckPerMetroInfo) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityCheckPerMetroInfo) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityCheckPerMetroInfo := _CapacityCheckPerMetroInfo{}
+
+	if err = json.Unmarshal(bytes, &varCapacityCheckPerMetroInfo); err == nil {
+		*o = CapacityCheckPerMetroInfo(varCapacityCheckPerMetroInfo)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "available")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "quantity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityCheckPerMetroInfo struct {

--- a/metal/v1/model_capacity_check_per_metro_list.go
+++ b/metal/v1/model_capacity_check_per_metro_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityCheckPerMetroList{}
 
 // CapacityCheckPerMetroList struct for CapacityCheckPerMetroList
 type CapacityCheckPerMetroList struct {
-	Servers []CapacityCheckPerMetroInfo `json:"servers,omitempty"`
+	Servers              []CapacityCheckPerMetroInfo `json:"servers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityCheckPerMetroList CapacityCheckPerMetroList
 
 // NewCapacityCheckPerMetroList instantiates a new CapacityCheckPerMetroList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityCheckPerMetroList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Servers) {
 		toSerialize["servers"] = o.Servers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityCheckPerMetroList) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityCheckPerMetroList := _CapacityCheckPerMetroList{}
+
+	if err = json.Unmarshal(bytes, &varCapacityCheckPerMetroList); err == nil {
+		*o = CapacityCheckPerMetroList(varCapacityCheckPerMetroList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "servers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityCheckPerMetroList struct {

--- a/metal/v1/model_capacity_input.go
+++ b/metal/v1/model_capacity_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityInput{}
 
 // CapacityInput struct for CapacityInput
 type CapacityInput struct {
-	Servers []ServerInfo `json:"servers,omitempty"`
+	Servers              []ServerInfo `json:"servers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityInput CapacityInput
 
 // NewCapacityInput instantiates a new CapacityInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Servers) {
 		toSerialize["servers"] = o.Servers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityInput) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityInput := _CapacityInput{}
+
+	if err = json.Unmarshal(bytes, &varCapacityInput); err == nil {
+		*o = CapacityInput(varCapacityInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "servers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityInput struct {

--- a/metal/v1/model_capacity_level_per_baremetal.go
+++ b/metal/v1/model_capacity_level_per_baremetal.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityLevelPerBaremetal{}
 
 // CapacityLevelPerBaremetal struct for CapacityLevelPerBaremetal
 type CapacityLevelPerBaremetal struct {
-	Level *string `json:"level,omitempty"`
+	Level                *string `json:"level,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityLevelPerBaremetal CapacityLevelPerBaremetal
 
 // NewCapacityLevelPerBaremetal instantiates a new CapacityLevelPerBaremetal object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityLevelPerBaremetal) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Level) {
 		toSerialize["level"] = o.Level
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityLevelPerBaremetal) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityLevelPerBaremetal := _CapacityLevelPerBaremetal{}
+
+	if err = json.Unmarshal(bytes, &varCapacityLevelPerBaremetal); err == nil {
+		*o = CapacityLevelPerBaremetal(varCapacityLevelPerBaremetal)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "level")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityLevelPerBaremetal struct {

--- a/metal/v1/model_capacity_list.go
+++ b/metal/v1/model_capacity_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityList{}
 
 // CapacityList struct for CapacityList
 type CapacityList struct {
-	Capacity *CapacityReport `json:"capacity,omitempty"`
+	Capacity             *CapacityReport `json:"capacity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityList CapacityList
 
 // NewCapacityList instantiates a new CapacityList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Capacity) {
 		toSerialize["capacity"] = o.Capacity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityList) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityList := _CapacityList{}
+
+	if err = json.Unmarshal(bytes, &varCapacityList); err == nil {
+		*o = CapacityList(varCapacityList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "capacity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityList struct {

--- a/metal/v1/model_capacity_per_facility.go
+++ b/metal/v1/model_capacity_per_facility.go
@@ -20,16 +20,19 @@ var _ MappedNullable = &CapacityPerFacility{}
 
 // CapacityPerFacility struct for CapacityPerFacility
 type CapacityPerFacility struct {
-	Baremetal0   *CapacityLevelPerBaremetal `json:"baremetal_0,omitempty"`
-	Baremetal1   *CapacityLevelPerBaremetal `json:"baremetal_1,omitempty"`
-	Baremetal2   *CapacityLevelPerBaremetal `json:"baremetal_2,omitempty"`
-	Baremetal2a  *CapacityLevelPerBaremetal `json:"baremetal_2a,omitempty"`
-	Baremetal2a2 *CapacityLevelPerBaremetal `json:"baremetal_2a2,omitempty"`
-	Baremetal3   *CapacityLevelPerBaremetal `json:"baremetal_3,omitempty"`
-	BaremetalS   *CapacityLevelPerBaremetal `json:"baremetal_s,omitempty"`
-	C2MediumX86  *CapacityLevelPerBaremetal `json:"c2.medium.x86,omitempty"`
-	M2XlargeX86  *CapacityLevelPerBaremetal `json:"m2.xlarge.x86,omitempty"`
+	Baremetal0           *CapacityLevelPerBaremetal `json:"baremetal_0,omitempty"`
+	Baremetal1           *CapacityLevelPerBaremetal `json:"baremetal_1,omitempty"`
+	Baremetal2           *CapacityLevelPerBaremetal `json:"baremetal_2,omitempty"`
+	Baremetal2a          *CapacityLevelPerBaremetal `json:"baremetal_2a,omitempty"`
+	Baremetal2a2         *CapacityLevelPerBaremetal `json:"baremetal_2a2,omitempty"`
+	Baremetal3           *CapacityLevelPerBaremetal `json:"baremetal_3,omitempty"`
+	BaremetalS           *CapacityLevelPerBaremetal `json:"baremetal_s,omitempty"`
+	C2MediumX86          *CapacityLevelPerBaremetal `json:"c2.medium.x86,omitempty"`
+	M2XlargeX86          *CapacityLevelPerBaremetal `json:"m2.xlarge.x86,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityPerFacility CapacityPerFacility
 
 // NewCapacityPerFacility instantiates a new CapacityPerFacility object
 // This constructor will assign default values to properties that have it defined,
@@ -373,7 +376,37 @@ func (o CapacityPerFacility) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.M2XlargeX86) {
 		toSerialize["m2.xlarge.x86"] = o.M2XlargeX86
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityPerFacility) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityPerFacility := _CapacityPerFacility{}
+
+	if err = json.Unmarshal(bytes, &varCapacityPerFacility); err == nil {
+		*o = CapacityPerFacility(varCapacityPerFacility)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "baremetal_0")
+		delete(additionalProperties, "baremetal_1")
+		delete(additionalProperties, "baremetal_2")
+		delete(additionalProperties, "baremetal_2a")
+		delete(additionalProperties, "baremetal_2a2")
+		delete(additionalProperties, "baremetal_3")
+		delete(additionalProperties, "baremetal_s")
+		delete(additionalProperties, "c2.medium.x86")
+		delete(additionalProperties, "m2.xlarge.x86")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityPerFacility struct {

--- a/metal/v1/model_capacity_per_metro_input.go
+++ b/metal/v1/model_capacity_per_metro_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityPerMetroInput{}
 
 // CapacityPerMetroInput struct for CapacityPerMetroInput
 type CapacityPerMetroInput struct {
-	Servers []MetroServerInfo `json:"servers,omitempty"`
+	Servers              []MetroServerInfo `json:"servers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityPerMetroInput CapacityPerMetroInput
 
 // NewCapacityPerMetroInput instantiates a new CapacityPerMetroInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityPerMetroInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Servers) {
 		toSerialize["servers"] = o.Servers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityPerMetroInput) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityPerMetroInput := _CapacityPerMetroInput{}
+
+	if err = json.Unmarshal(bytes, &varCapacityPerMetroInput); err == nil {
+		*o = CapacityPerMetroInput(varCapacityPerMetroInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "servers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityPerMetroInput struct {

--- a/metal/v1/model_capacity_per_new_facility.go
+++ b/metal/v1/model_capacity_per_new_facility.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CapacityPerNewFacility{}
 
 // CapacityPerNewFacility struct for CapacityPerNewFacility
 type CapacityPerNewFacility struct {
-	Baremetal1e *CapacityLevelPerBaremetal `json:"baremetal_1e,omitempty"`
+	Baremetal1e          *CapacityLevelPerBaremetal `json:"baremetal_1e,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityPerNewFacility CapacityPerNewFacility
 
 // NewCapacityPerNewFacility instantiates a new CapacityPerNewFacility object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o CapacityPerNewFacility) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Baremetal1e) {
 		toSerialize["baremetal_1e"] = o.Baremetal1e
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityPerNewFacility) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityPerNewFacility := _CapacityPerNewFacility{}
+
+	if err = json.Unmarshal(bytes, &varCapacityPerNewFacility); err == nil {
+		*o = CapacityPerNewFacility(varCapacityPerNewFacility)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "baremetal_1e")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityPerNewFacility struct {

--- a/metal/v1/model_capacity_report.go
+++ b/metal/v1/model_capacity_report.go
@@ -20,21 +20,24 @@ var _ MappedNullable = &CapacityReport{}
 
 // CapacityReport struct for CapacityReport
 type CapacityReport struct {
-	Ams1 *CapacityPerFacility    `json:"ams1,omitempty"`
-	Atl1 *CapacityPerNewFacility `json:"atl1,omitempty"`
-	Dfw1 *CapacityPerNewFacility `json:"dfw1,omitempty"`
-	Ewr1 *CapacityPerFacility    `json:"ewr1,omitempty"`
-	Fra1 *CapacityPerNewFacility `json:"fra1,omitempty"`
-	Iad1 *CapacityPerNewFacility `json:"iad1,omitempty"`
-	Lax1 *CapacityPerNewFacility `json:"lax1,omitempty"`
-	Nrt1 *CapacityPerFacility    `json:"nrt1,omitempty"`
-	Ord1 *CapacityPerNewFacility `json:"ord1,omitempty"`
-	Sea1 *CapacityPerNewFacility `json:"sea1,omitempty"`
-	Sin1 *CapacityPerNewFacility `json:"sin1,omitempty"`
-	Sjc1 *CapacityPerFacility    `json:"sjc1,omitempty"`
-	Syd1 *CapacityPerNewFacility `json:"syd1,omitempty"`
-	Yyz1 *CapacityPerNewFacility `json:"yyz1,omitempty"`
+	Ams1                 *CapacityPerFacility    `json:"ams1,omitempty"`
+	Atl1                 *CapacityPerNewFacility `json:"atl1,omitempty"`
+	Dfw1                 *CapacityPerNewFacility `json:"dfw1,omitempty"`
+	Ewr1                 *CapacityPerFacility    `json:"ewr1,omitempty"`
+	Fra1                 *CapacityPerNewFacility `json:"fra1,omitempty"`
+	Iad1                 *CapacityPerNewFacility `json:"iad1,omitempty"`
+	Lax1                 *CapacityPerNewFacility `json:"lax1,omitempty"`
+	Nrt1                 *CapacityPerFacility    `json:"nrt1,omitempty"`
+	Ord1                 *CapacityPerNewFacility `json:"ord1,omitempty"`
+	Sea1                 *CapacityPerNewFacility `json:"sea1,omitempty"`
+	Sin1                 *CapacityPerNewFacility `json:"sin1,omitempty"`
+	Sjc1                 *CapacityPerFacility    `json:"sjc1,omitempty"`
+	Syd1                 *CapacityPerNewFacility `json:"syd1,omitempty"`
+	Yyz1                 *CapacityPerNewFacility `json:"yyz1,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CapacityReport CapacityReport
 
 // NewCapacityReport instantiates a new CapacityReport object
 // This constructor will assign default values to properties that have it defined,
@@ -553,7 +556,42 @@ func (o CapacityReport) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Yyz1) {
 		toSerialize["yyz1"] = o.Yyz1
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CapacityReport) UnmarshalJSON(bytes []byte) (err error) {
+	varCapacityReport := _CapacityReport{}
+
+	if err = json.Unmarshal(bytes, &varCapacityReport); err == nil {
+		*o = CapacityReport(varCapacityReport)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ams1")
+		delete(additionalProperties, "atl1")
+		delete(additionalProperties, "dfw1")
+		delete(additionalProperties, "ewr1")
+		delete(additionalProperties, "fra1")
+		delete(additionalProperties, "iad1")
+		delete(additionalProperties, "lax1")
+		delete(additionalProperties, "nrt1")
+		delete(additionalProperties, "ord1")
+		delete(additionalProperties, "sea1")
+		delete(additionalProperties, "sin1")
+		delete(additionalProperties, "sjc1")
+		delete(additionalProperties, "syd1")
+		delete(additionalProperties, "yyz1")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCapacityReport struct {

--- a/metal/v1/model_coordinates.go
+++ b/metal/v1/model_coordinates.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &Coordinates{}
 
 // Coordinates struct for Coordinates
 type Coordinates struct {
-	Latitude  *string `json:"latitude,omitempty"`
-	Longitude *string `json:"longitude,omitempty"`
+	Latitude             *string `json:"latitude,omitempty"`
+	Longitude            *string `json:"longitude,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Coordinates Coordinates
 
 // NewCoordinates instantiates a new Coordinates object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o Coordinates) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Longitude) {
 		toSerialize["longitude"] = o.Longitude
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Coordinates) UnmarshalJSON(bytes []byte) (err error) {
+	varCoordinates := _Coordinates{}
+
+	if err = json.Unmarshal(bytes, &varCoordinates); err == nil {
+		*o = Coordinates(varCoordinates)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "latitude")
+		delete(additionalProperties, "longitude")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCoordinates struct {

--- a/metal/v1/model_create_email_input.go
+++ b/metal/v1/model_create_email_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &CreateEmailInput{}
 
 // CreateEmailInput struct for CreateEmailInput
 type CreateEmailInput struct {
-	Address string `json:"address"`
+	Address              string `json:"address"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateEmailInput CreateEmailInput
 
 // NewCreateEmailInput instantiates a new CreateEmailInput object
 // This constructor will assign default values to properties that have it defined,
@@ -76,7 +79,29 @@ func (o CreateEmailInput) MarshalJSON() ([]byte, error) {
 func (o CreateEmailInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["address"] = o.Address
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateEmailInput) UnmarshalJSON(bytes []byte) (err error) {
+	varCreateEmailInput := _CreateEmailInput{}
+
+	if err = json.Unmarshal(bytes, &varCreateEmailInput); err == nil {
+		*o = CreateEmailInput(varCreateEmailInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateEmailInput struct {

--- a/metal/v1/model_create_self_service_reservation_request.go
+++ b/metal/v1/model_create_self_service_reservation_request.go
@@ -21,11 +21,14 @@ var _ MappedNullable = &CreateSelfServiceReservationRequest{}
 
 // CreateSelfServiceReservationRequest struct for CreateSelfServiceReservationRequest
 type CreateSelfServiceReservationRequest struct {
-	Item      []SelfServiceReservationItemRequest        `json:"item,omitempty"`
-	Notes     *string                                    `json:"notes,omitempty"`
-	Period    *CreateSelfServiceReservationRequestPeriod `json:"period,omitempty"`
-	StartDate *time.Time                                 `json:"start_date,omitempty"`
+	Item                 []SelfServiceReservationItemRequest        `json:"item,omitempty"`
+	Notes                *string                                    `json:"notes,omitempty"`
+	Period               *CreateSelfServiceReservationRequestPeriod `json:"period,omitempty"`
+	StartDate            *time.Time                                 `json:"start_date,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateSelfServiceReservationRequest CreateSelfServiceReservationRequest
 
 // NewCreateSelfServiceReservationRequest instantiates a new CreateSelfServiceReservationRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -194,7 +197,32 @@ func (o CreateSelfServiceReservationRequest) ToMap() (map[string]interface{}, er
 	if !isNil(o.StartDate) {
 		toSerialize["start_date"] = o.StartDate
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateSelfServiceReservationRequest) UnmarshalJSON(bytes []byte) (err error) {
+	varCreateSelfServiceReservationRequest := _CreateSelfServiceReservationRequest{}
+
+	if err = json.Unmarshal(bytes, &varCreateSelfServiceReservationRequest); err == nil {
+		*o = CreateSelfServiceReservationRequest(varCreateSelfServiceReservationRequest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "item")
+		delete(additionalProperties, "notes")
+		delete(additionalProperties, "period")
+		delete(additionalProperties, "start_date")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateSelfServiceReservationRequest struct {

--- a/metal/v1/model_create_self_service_reservation_request_period.go
+++ b/metal/v1/model_create_self_service_reservation_request_period.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &CreateSelfServiceReservationRequestPeriod{}
 
 // CreateSelfServiceReservationRequestPeriod struct for CreateSelfServiceReservationRequestPeriod
 type CreateSelfServiceReservationRequestPeriod struct {
-	Count *float32 `json:"count,omitempty"`
-	Unit  *string  `json:"unit,omitempty"`
+	Count                *float32 `json:"count,omitempty"`
+	Unit                 *string  `json:"unit,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateSelfServiceReservationRequestPeriod CreateSelfServiceReservationRequestPeriod
 
 // NewCreateSelfServiceReservationRequestPeriod instantiates a new CreateSelfServiceReservationRequestPeriod object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o CreateSelfServiceReservationRequestPeriod) ToMap() (map[string]interface
 	if !isNil(o.Unit) {
 		toSerialize["unit"] = o.Unit
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateSelfServiceReservationRequestPeriod) UnmarshalJSON(bytes []byte) (err error) {
+	varCreateSelfServiceReservationRequestPeriod := _CreateSelfServiceReservationRequestPeriod{}
+
+	if err = json.Unmarshal(bytes, &varCreateSelfServiceReservationRequestPeriod); err == nil {
+		*o = CreateSelfServiceReservationRequestPeriod(varCreateSelfServiceReservationRequestPeriod)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "count")
+		delete(additionalProperties, "unit")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateSelfServiceReservationRequestPeriod struct {

--- a/metal/v1/model_device.go
+++ b/metal/v1/model_device.go
@@ -64,12 +64,15 @@ type Device struct {
 	SwitchUuid *string  `json:"switch_uuid,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 	// When the device will be terminated. This is commonly set in advance for ephemeral spot market instances but this field may also be set with on-demand and reservation instances to automatically delete the resource at a given time. The termination time can also be used to release a hardware reservation instance at a given time, keeping the reservation open for other uses.  On a spot market device, the termination time will be set automatically when outbid.
-	TerminationTime *time.Time `json:"termination_time,omitempty"`
-	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
-	User            *string    `json:"user,omitempty"`
-	Userdata        *string    `json:"userdata,omitempty"`
-	Volumes         []Href     `json:"volumes,omitempty"`
+	TerminationTime      *time.Time `json:"termination_time,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	User                 *string    `json:"user,omitempty"`
+	Userdata             *string    `json:"userdata,omitempty"`
+	Volumes              []Href     `json:"volumes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Device Device
 
 // NewDevice instantiates a new Device object
 // This constructor will assign default values to properties that have it defined,
@@ -1498,7 +1501,68 @@ func (o Device) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Device) UnmarshalJSON(bytes []byte) (err error) {
+	varDevice := _Device{}
+
+	if err = json.Unmarshal(bytes, &varDevice); err == nil {
+		*o = Device(varDevice)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "bonding_mode")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "created_by")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "hardware_reservation")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "image_url")
+		delete(additionalProperties, "ip_addresses")
+		delete(additionalProperties, "ipxe_script_url")
+		delete(additionalProperties, "iqn")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "network_ports")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "actions")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "project_lite")
+		delete(additionalProperties, "provisioning_events")
+		delete(additionalProperties, "provisioning_percentage")
+		delete(additionalProperties, "root_password")
+		delete(additionalProperties, "short_id")
+		delete(additionalProperties, "spot_instance")
+		delete(additionalProperties, "spot_price_max")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "storage")
+		delete(additionalProperties, "switch_uuid")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "termination_time")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "user")
+		delete(additionalProperties, "userdata")
+		delete(additionalProperties, "volumes")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDevice struct {

--- a/metal/v1/model_device_action_input.go
+++ b/metal/v1/model_device_action_input.go
@@ -31,8 +31,11 @@ type DeviceActionInput struct {
 	// When type is `reinstall`, use this `operating_system` (defaults to the current `operating system`)
 	OperatingSystem *string `json:"operating_system,omitempty"`
 	// When type is `reinstall`, use this `ipxe_script_url` (`operating_system` must be `custom_ipxe`, defaults to the current `ipxe_script_url`)
-	IpxeScriptUrl *string `json:"ipxe_script_url,omitempty"`
+	IpxeScriptUrl        *string `json:"ipxe_script_url,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceActionInput DeviceActionInput
 
 // NewDeviceActionInput instantiates a new DeviceActionInput object
 // This constructor will assign default values to properties that have it defined,
@@ -262,7 +265,34 @@ func (o DeviceActionInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.IpxeScriptUrl) {
 		toSerialize["ipxe_script_url"] = o.IpxeScriptUrl
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceActionInput) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceActionInput := _DeviceActionInput{}
+
+	if err = json.Unmarshal(bytes, &varDeviceActionInput); err == nil {
+		*o = DeviceActionInput(varDeviceActionInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "force_delete")
+		delete(additionalProperties, "deprovision_fast")
+		delete(additionalProperties, "preserve_data")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "ipxe_script_url")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceActionInput struct {

--- a/metal/v1/model_device_actions_inner.go
+++ b/metal/v1/model_device_actions_inner.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &DeviceActionsInner{}
 
 // DeviceActionsInner struct for DeviceActionsInner
 type DeviceActionsInner struct {
-	Type *string `json:"type,omitempty"`
-	Name *string `json:"name,omitempty"`
+	Type                 *string `json:"type,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceActionsInner DeviceActionsInner
 
 // NewDeviceActionsInner instantiates a new DeviceActionsInner object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o DeviceActionsInner) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceActionsInner) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceActionsInner := _DeviceActionsInner{}
+
+	if err = json.Unmarshal(bytes, &varDeviceActionsInner); err == nil {
+		*o = DeviceActionsInner(varDeviceActionsInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceActionsInner struct {

--- a/metal/v1/model_device_create_in_facility_input.go
+++ b/metal/v1/model_device_create_in_facility_input.go
@@ -65,8 +65,11 @@ type DeviceCreateInFacilityInput struct {
 	// A list of UUIDs identifying the users that should be authorized to access this device (typically via /root/.ssh/authorized_keys).  These keys will also appear in the device metadata.  The users must be members of the project or organization.  If no SSH keys are specified (`user_ssh_keys`, `project_ssh_keys`, and `ssh_keys` are all empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included. This behaviour can be changed with 'no_ssh_keys' option to omit any SSH key being added.
 	UserSshKeys []string `json:"user_ssh_keys,omitempty"`
 	// The userdata presented in the metadata service for this device.  Userdata is fetched and interpreted by the operating system installed on the device. Acceptable formats are determined by the operating system, with the exception of a special iPXE enabling syntax which is handled before the operating system starts.  See [Server User Data](https://metal.equinix.com/developers/docs/servers/user-data/) and [Provisioning with Custom iPXE](https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/#provisioning-with-custom-ipxe) for more details.
-	Userdata *string `json:"userdata,omitempty"`
+	Userdata             *string `json:"userdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceCreateInFacilityInput DeviceCreateInFacilityInput
 
 // NewDeviceCreateInFacilityInput instantiates a new DeviceCreateInFacilityInput object
 // This constructor will assign default values to properties that have it defined,
@@ -932,7 +935,52 @@ func (o DeviceCreateInFacilityInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Userdata) {
 		toSerialize["userdata"] = o.Userdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceCreateInFacilityInput) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceCreateInFacilityInput := _DeviceCreateInFacilityInput{}
+
+	if err = json.Unmarshal(bytes, &varDeviceCreateInFacilityInput); err == nil {
+		*o = DeviceCreateInFacilityInput(varDeviceCreateInFacilityInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "hardware_reservation_id")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "ip_addresses")
+		delete(additionalProperties, "ipxe_script_url")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "no_ssh_keys")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "private_ipv4_subnet_size")
+		delete(additionalProperties, "project_ssh_keys")
+		delete(additionalProperties, "public_ipv4_subnet_size")
+		delete(additionalProperties, "spot_instance")
+		delete(additionalProperties, "spot_price_max")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "termination_time")
+		delete(additionalProperties, "user_ssh_keys")
+		delete(additionalProperties, "userdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceCreateInFacilityInput struct {

--- a/metal/v1/model_device_create_in_metro_input.go
+++ b/metal/v1/model_device_create_in_metro_input.go
@@ -66,8 +66,11 @@ type DeviceCreateInMetroInput struct {
 	// A list of UUIDs identifying the users that should be authorized to access this device (typically via /root/.ssh/authorized_keys).  These keys will also appear in the device metadata.  The users must be members of the project or organization.  If no SSH keys are specified (`user_ssh_keys`, `project_ssh_keys`, and `ssh_keys` are all empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included. This behaviour can be changed with 'no_ssh_keys' option to omit any SSH key being added.
 	UserSshKeys []string `json:"user_ssh_keys,omitempty"`
 	// The userdata presented in the metadata service for this device.  Userdata is fetched and interpreted by the operating system installed on the device. Acceptable formats are determined by the operating system, with the exception of a special iPXE enabling syntax which is handled before the operating system starts.  See [Server User Data](https://metal.equinix.com/developers/docs/servers/user-data/) and [Provisioning with Custom iPXE](https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/#provisioning-with-custom-ipxe) for more details.
-	Userdata *string `json:"userdata,omitempty"`
+	Userdata             *string `json:"userdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceCreateInMetroInput DeviceCreateInMetroInput
 
 // NewDeviceCreateInMetroInput instantiates a new DeviceCreateInMetroInput object
 // This constructor will assign default values to properties that have it defined,
@@ -933,7 +936,52 @@ func (o DeviceCreateInMetroInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Userdata) {
 		toSerialize["userdata"] = o.Userdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceCreateInMetroInput) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceCreateInMetroInput := _DeviceCreateInMetroInput{}
+
+	if err = json.Unmarshal(bytes, &varDeviceCreateInMetroInput); err == nil {
+		*o = DeviceCreateInMetroInput(varDeviceCreateInMetroInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "hardware_reservation_id")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "ip_addresses")
+		delete(additionalProperties, "ipxe_script_url")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "no_ssh_keys")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "private_ipv4_subnet_size")
+		delete(additionalProperties, "project_ssh_keys")
+		delete(additionalProperties, "public_ipv4_subnet_size")
+		delete(additionalProperties, "spot_instance")
+		delete(additionalProperties, "spot_price_max")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "termination_time")
+		delete(additionalProperties, "user_ssh_keys")
+		delete(additionalProperties, "userdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceCreateInMetroInput struct {

--- a/metal/v1/model_device_create_input.go
+++ b/metal/v1/model_device_create_input.go
@@ -64,8 +64,11 @@ type DeviceCreateInput struct {
 	// A list of UUIDs identifying the users that should be authorized to access this device (typically via /root/.ssh/authorized_keys).  These keys will also appear in the device metadata.  The users must be members of the project or organization.  If no SSH keys are specified (`user_ssh_keys`, `project_ssh_keys`, and `ssh_keys` are all empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included. This behaviour can be changed with 'no_ssh_keys' option to omit any SSH key being added.
 	UserSshKeys []string `json:"user_ssh_keys,omitempty"`
 	// The userdata presented in the metadata service for this device.  Userdata is fetched and interpreted by the operating system installed on the device. Acceptable formats are determined by the operating system, with the exception of a special iPXE enabling syntax which is handled before the operating system starts.  See [Server User Data](https://metal.equinix.com/developers/docs/servers/user-data/) and [Provisioning with Custom iPXE](https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/#provisioning-with-custom-ipxe) for more details.
-	Userdata *string `json:"userdata,omitempty"`
+	Userdata             *string `json:"userdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceCreateInput DeviceCreateInput
 
 // NewDeviceCreateInput instantiates a new DeviceCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -905,7 +908,51 @@ func (o DeviceCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Userdata) {
 		toSerialize["userdata"] = o.Userdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceCreateInput := _DeviceCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varDeviceCreateInput); err == nil {
+		*o = DeviceCreateInput(varDeviceCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "hardware_reservation_id")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "ip_addresses")
+		delete(additionalProperties, "ipxe_script_url")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "no_ssh_keys")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "private_ipv4_subnet_size")
+		delete(additionalProperties, "project_ssh_keys")
+		delete(additionalProperties, "public_ipv4_subnet_size")
+		delete(additionalProperties, "spot_instance")
+		delete(additionalProperties, "spot_price_max")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "termination_time")
+		delete(additionalProperties, "user_ssh_keys")
+		delete(additionalProperties, "userdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceCreateInput struct {

--- a/metal/v1/model_device_create_input_ip_addresses_inner.go
+++ b/metal/v1/model_device_create_input_ip_addresses_inner.go
@@ -27,8 +27,11 @@ type DeviceCreateInputIpAddressesInner struct {
 	// UUIDs of any IP reservations to use when assigning IPs
 	IpReservations []string `json:"ip_reservations,omitempty"`
 	// Address Type for IP Address
-	Public *bool `json:"public,omitempty"`
+	Public               *bool `json:"public,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceCreateInputIpAddressesInner DeviceCreateInputIpAddressesInner
 
 // NewDeviceCreateInputIpAddressesInner instantiates a new DeviceCreateInputIpAddressesInner object
 // This constructor will assign default values to properties that have it defined,
@@ -201,7 +204,32 @@ func (o DeviceCreateInputIpAddressesInner) ToMap() (map[string]interface{}, erro
 	if !isNil(o.Public) {
 		toSerialize["public"] = o.Public
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceCreateInputIpAddressesInner) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceCreateInputIpAddressesInner := _DeviceCreateInputIpAddressesInner{}
+
+	if err = json.Unmarshal(bytes, &varDeviceCreateInputIpAddressesInner); err == nil {
+		*o = DeviceCreateInputIpAddressesInner(varDeviceCreateInputIpAddressesInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "cidr")
+		delete(additionalProperties, "ip_reservations")
+		delete(additionalProperties, "public")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceCreateInputIpAddressesInner struct {

--- a/metal/v1/model_device_created_by.go
+++ b/metal/v1/model_device_created_by.go
@@ -40,8 +40,11 @@ type DeviceCreatedBy struct {
 	// Short ID of the User
 	ShortId string `json:"short_id"`
 	// When the user details were last updated
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceCreatedBy DeviceCreatedBy
 
 // NewDeviceCreatedBy instantiates a new DeviceCreatedBy object
 // This constructor will assign default values to properties that have it defined,
@@ -402,7 +405,38 @@ func (o DeviceCreatedBy) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceCreatedBy) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceCreatedBy := _DeviceCreatedBy{}
+
+	if err = json.Unmarshal(bytes, &varDeviceCreatedBy); err == nil {
+		*o = DeviceCreatedBy(varDeviceCreatedBy)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "avatar_thumb_url")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "full_name")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "short_id")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceCreatedBy struct {

--- a/metal/v1/model_device_list.go
+++ b/metal/v1/model_device_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &DeviceList{}
 
 // DeviceList struct for DeviceList
 type DeviceList struct {
-	Devices []Device `json:"devices,omitempty"`
-	Meta    *Meta    `json:"meta,omitempty"`
+	Devices              []Device `json:"devices,omitempty"`
+	Meta                 *Meta    `json:"meta,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceList DeviceList
 
 // NewDeviceList instantiates a new DeviceList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o DeviceList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Meta) {
 		toSerialize["meta"] = o.Meta
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceList) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceList := _DeviceList{}
+
+	if err = json.Unmarshal(bytes, &varDeviceList); err == nil {
+		*o = DeviceList(varDeviceList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "devices")
+		delete(additionalProperties, "meta")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceList struct {

--- a/metal/v1/model_device_metro.go
+++ b/metal/v1/model_device_metro.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &DeviceMetro{}
 
 // DeviceMetro struct for DeviceMetro
 type DeviceMetro struct {
-	Code    *string `json:"code,omitempty"`
-	Country *string `json:"country,omitempty"`
-	Id      *string `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
+	Code                 *string `json:"code,omitempty"`
+	Country              *string `json:"country,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceMetro DeviceMetro
 
 // NewDeviceMetro instantiates a new DeviceMetro object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o DeviceMetro) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceMetro) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceMetro := _DeviceMetro{}
+
+	if err = json.Unmarshal(bytes, &varDeviceMetro); err == nil {
+		*o = DeviceMetro(varDeviceMetro)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceMetro struct {

--- a/metal/v1/model_device_project_lite.go
+++ b/metal/v1/model_device_project_lite.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &DeviceProjectLite{}
 
 // DeviceProjectLite struct for DeviceProjectLite
 type DeviceProjectLite struct {
-	Href string `json:"href"`
+	Href                 string `json:"href"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceProjectLite DeviceProjectLite
 
 // NewDeviceProjectLite instantiates a new DeviceProjectLite object
 // This constructor will assign default values to properties that have it defined,
@@ -76,7 +79,29 @@ func (o DeviceProjectLite) MarshalJSON() ([]byte, error) {
 func (o DeviceProjectLite) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["href"] = o.Href
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceProjectLite) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceProjectLite := _DeviceProjectLite{}
+
+	if err = json.Unmarshal(bytes, &varDeviceProjectLite); err == nil {
+		*o = DeviceProjectLite(varDeviceProjectLite)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "href")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceProjectLite struct {

--- a/metal/v1/model_device_update_input.go
+++ b/metal/v1/model_device_update_input.go
@@ -30,10 +30,13 @@ type DeviceUpdateInput struct {
 	// If true, this instance can not be converted to a different network type.
 	NetworkFrozen *bool `json:"network_frozen,omitempty"`
 	// Can be set to false to convert a spot-market instance to on-demand.
-	SpotInstance *bool    `json:"spot_instance,omitempty"`
-	Tags         []string `json:"tags,omitempty"`
-	Userdata     *string  `json:"userdata,omitempty"`
+	SpotInstance         *bool    `json:"spot_instance,omitempty"`
+	Tags                 []string `json:"tags,omitempty"`
+	Userdata             *string  `json:"userdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceUpdateInput DeviceUpdateInput
 
 // NewDeviceUpdateInput instantiates a new DeviceUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -447,7 +450,39 @@ func (o DeviceUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Userdata) {
 		toSerialize["userdata"] = o.Userdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceUpdateInput := _DeviceUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varDeviceUpdateInput); err == nil {
+		*o = DeviceUpdateInput(varDeviceUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "ipxe_script_url")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "network_frozen")
+		delete(additionalProperties, "spot_instance")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "userdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceUpdateInput struct {

--- a/metal/v1/model_device_usage.go
+++ b/metal/v1/model_device_usage.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &DeviceUsage{}
 
 // DeviceUsage struct for DeviceUsage
 type DeviceUsage struct {
-	Quantity *string `json:"quantity,omitempty"`
-	Total    *string `json:"total,omitempty"`
-	Unit     *string `json:"unit,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
+	Total                *string `json:"total,omitempty"`
+	Unit                 *string `json:"unit,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceUsage DeviceUsage
 
 // NewDeviceUsage instantiates a new DeviceUsage object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o DeviceUsage) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Unit) {
 		toSerialize["unit"] = o.Unit
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceUsage) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceUsage := _DeviceUsage{}
+
+	if err = json.Unmarshal(bytes, &varDeviceUsage); err == nil {
+		*o = DeviceUsage(varDeviceUsage)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "unit")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceUsage struct {

--- a/metal/v1/model_device_usage_list.go
+++ b/metal/v1/model_device_usage_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &DeviceUsageList{}
 
 // DeviceUsageList struct for DeviceUsageList
 type DeviceUsageList struct {
-	Usages []DeviceUsage `json:"usages,omitempty"`
+	Usages               []DeviceUsage `json:"usages,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DeviceUsageList DeviceUsageList
 
 // NewDeviceUsageList instantiates a new DeviceUsageList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o DeviceUsageList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Usages) {
 		toSerialize["usages"] = o.Usages
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DeviceUsageList) UnmarshalJSON(bytes []byte) (err error) {
+	varDeviceUsageList := _DeviceUsageList{}
+
+	if err = json.Unmarshal(bytes, &varDeviceUsageList); err == nil {
+		*o = DeviceUsageList(varDeviceUsageList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "usages")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDeviceUsageList struct {

--- a/metal/v1/model_disk.go
+++ b/metal/v1/model_disk.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &Disk{}
 
 // Disk struct for Disk
 type Disk struct {
-	Device     *string     `json:"device,omitempty"`
-	WipeTable  *bool       `json:"wipeTable,omitempty"`
-	Partitions []Partition `json:"partitions,omitempty"`
+	Device               *string     `json:"device,omitempty"`
+	WipeTable            *bool       `json:"wipeTable,omitempty"`
+	Partitions           []Partition `json:"partitions,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Disk Disk
 
 // NewDisk instantiates a new Disk object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o Disk) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Partitions) {
 		toSerialize["partitions"] = o.Partitions
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Disk) UnmarshalJSON(bytes []byte) (err error) {
+	varDisk := _Disk{}
+
+	if err = json.Unmarshal(bytes, &varDisk); err == nil {
+		*o = Disk(varDisk)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "device")
+		delete(additionalProperties, "wipeTable")
+		delete(additionalProperties, "partitions")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDisk struct {

--- a/metal/v1/model_email.go
+++ b/metal/v1/model_email.go
@@ -20,12 +20,15 @@ var _ MappedNullable = &Email{}
 
 // Email struct for Email
 type Email struct {
-	Address  *string `json:"address,omitempty"`
-	Default  *bool   `json:"default,omitempty"`
-	Href     *string `json:"href,omitempty"`
-	Id       *string `json:"id,omitempty"`
-	Verified *bool   `json:"verified,omitempty"`
+	Address              *string `json:"address,omitempty"`
+	Default              *bool   `json:"default,omitempty"`
+	Href                 *string `json:"href,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Verified             *bool   `json:"verified,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Email Email
 
 // NewEmail instantiates a new Email object
 // This constructor will assign default values to properties that have it defined,
@@ -229,7 +232,33 @@ func (o Email) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Verified) {
 		toSerialize["verified"] = o.Verified
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Email) UnmarshalJSON(bytes []byte) (err error) {
+	varEmail := _Email{}
+
+	if err = json.Unmarshal(bytes, &varEmail); err == nil {
+		*o = Email(varEmail)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "verified")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEmail struct {

--- a/metal/v1/model_email_input.go
+++ b/metal/v1/model_email_input.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &EmailInput{}
 
 // EmailInput struct for EmailInput
 type EmailInput struct {
-	Address string `json:"address"`
-	Default *bool  `json:"default,omitempty"`
+	Address              string `json:"address"`
+	Default              *bool  `json:"default,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _EmailInput EmailInput
 
 // NewEmailInput instantiates a new EmailInput object
 // This constructor will assign default values to properties that have it defined,
@@ -112,7 +115,30 @@ func (o EmailInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Default) {
 		toSerialize["default"] = o.Default
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *EmailInput) UnmarshalJSON(bytes []byte) (err error) {
+	varEmailInput := _EmailInput{}
+
+	if err = json.Unmarshal(bytes, &varEmailInput); err == nil {
+		*o = EmailInput(varEmailInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "default")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEmailInput struct {

--- a/metal/v1/model_entitlement.go
+++ b/metal/v1/model_entitlement.go
@@ -20,19 +20,22 @@ var _ MappedNullable = &Entitlement{}
 
 // Entitlement struct for Entitlement
 type Entitlement struct {
-	Description   *string                `json:"description,omitempty"`
-	FeatureAccess map[string]interface{} `json:"feature_access,omitempty"`
-	Href          *string                `json:"href,omitempty"`
-	Id            string                 `json:"id"`
-	InstanceQuota map[string]interface{} `json:"instance_quota,omitempty"`
-	IpQuota       map[string]interface{} `json:"ip_quota,omitempty"`
-	Name          *string                `json:"name,omitempty"`
-	ProjectQuota  *int32                 `json:"project_quota,omitempty"`
-	Slug          string                 `json:"slug"`
-	VolumeLimits  map[string]interface{} `json:"volume_limits,omitempty"`
-	VolumeQuota   map[string]interface{} `json:"volume_quota,omitempty"`
-	Weight        int32                  `json:"weight"`
+	Description          *string                `json:"description,omitempty"`
+	FeatureAccess        map[string]interface{} `json:"feature_access,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   string                 `json:"id"`
+	InstanceQuota        map[string]interface{} `json:"instance_quota,omitempty"`
+	IpQuota              map[string]interface{} `json:"ip_quota,omitempty"`
+	Name                 *string                `json:"name,omitempty"`
+	ProjectQuota         *int32                 `json:"project_quota,omitempty"`
+	Slug                 string                 `json:"slug"`
+	VolumeLimits         map[string]interface{} `json:"volume_limits,omitempty"`
+	VolumeQuota          map[string]interface{} `json:"volume_quota,omitempty"`
+	Weight               int32                  `json:"weight"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Entitlement Entitlement
 
 // NewEntitlement instantiates a new Entitlement object
 // This constructor will assign default values to properties that have it defined,
@@ -458,7 +461,40 @@ func (o Entitlement) ToMap() (map[string]interface{}, error) {
 		toSerialize["volume_quota"] = o.VolumeQuota
 	}
 	toSerialize["weight"] = o.Weight
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Entitlement) UnmarshalJSON(bytes []byte) (err error) {
+	varEntitlement := _Entitlement{}
+
+	if err = json.Unmarshal(bytes, &varEntitlement); err == nil {
+		*o = Entitlement(varEntitlement)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "feature_access")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "instance_quota")
+		delete(additionalProperties, "ip_quota")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "project_quota")
+		delete(additionalProperties, "slug")
+		delete(additionalProperties, "volume_limits")
+		delete(additionalProperties, "volume_quota")
+		delete(additionalProperties, "weight")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEntitlement struct {

--- a/metal/v1/model_error.go
+++ b/metal/v1/model_error.go
@@ -23,8 +23,11 @@ type Error struct {
 	// A description of the error that caused the request to fail.
 	Error *string `json:"error,omitempty"`
 	// A list of errors that contributed to the request failing.
-	Errors []string `json:"errors,omitempty"`
+	Errors               []string `json:"errors,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Error Error
 
 // NewError instantiates a new Error object
 // This constructor will assign default values to properties that have it defined,
@@ -123,7 +126,30 @@ func (o Error) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Errors) {
 		toSerialize["errors"] = o.Errors
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Error) UnmarshalJSON(bytes []byte) (err error) {
+	varError := _Error{}
+
+	if err = json.Unmarshal(bytes, &varError); err == nil {
+		*o = Error(varError)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "error")
+		delete(additionalProperties, "errors")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableError struct {

--- a/metal/v1/model_event.go
+++ b/metal/v1/model_event.go
@@ -21,17 +21,20 @@ var _ MappedNullable = &Event{}
 
 // Event struct for Event
 type Event struct {
-	Body          *string                `json:"body,omitempty"`
-	CreatedAt     *time.Time             `json:"created_at,omitempty"`
-	Href          *string                `json:"href,omitempty"`
-	Id            *string                `json:"id,omitempty"`
-	Interpolated  *string                `json:"interpolated,omitempty"`
-	Relationships []Href                 `json:"relationships,omitempty"`
-	State         *string                `json:"state,omitempty"`
-	Type          *string                `json:"type,omitempty"`
-	ModifiedBy    map[string]interface{} `json:"modified_by,omitempty"`
-	Ip            *string                `json:"ip,omitempty"`
+	Body                 *string                `json:"body,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   *string                `json:"id,omitempty"`
+	Interpolated         *string                `json:"interpolated,omitempty"`
+	Relationships        []Href                 `json:"relationships,omitempty"`
+	State                *string                `json:"state,omitempty"`
+	Type                 *string                `json:"type,omitempty"`
+	ModifiedBy           map[string]interface{} `json:"modified_by,omitempty"`
+	Ip                   *string                `json:"ip,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Event Event
 
 // NewEvent instantiates a new Event object
 // This constructor will assign default values to properties that have it defined,
@@ -410,7 +413,38 @@ func (o Event) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Ip) {
 		toSerialize["ip"] = o.Ip
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Event) UnmarshalJSON(bytes []byte) (err error) {
+	varEvent := _Event{}
+
+	if err = json.Unmarshal(bytes, &varEvent); err == nil {
+		*o = Event(varEvent)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "body")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "interpolated")
+		delete(additionalProperties, "relationships")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "modified_by")
+		delete(additionalProperties, "ip")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEvent struct {

--- a/metal/v1/model_event_list.go
+++ b/metal/v1/model_event_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &EventList{}
 
 // EventList struct for EventList
 type EventList struct {
-	Events []Event `json:"events,omitempty"`
-	Meta   *Meta   `json:"meta,omitempty"`
+	Events               []Event `json:"events,omitempty"`
+	Meta                 *Meta   `json:"meta,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _EventList EventList
 
 // NewEventList instantiates a new EventList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o EventList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Meta) {
 		toSerialize["meta"] = o.Meta
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *EventList) UnmarshalJSON(bytes []byte) (err error) {
+	varEventList := _EventList{}
+
+	if err = json.Unmarshal(bytes, &varEventList); err == nil {
+		*o = EventList(varEventList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "events")
+		delete(additionalProperties, "meta")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableEventList struct {

--- a/metal/v1/model_fabric_service_token.go
+++ b/metal/v1/model_fabric_service_token.go
@@ -32,8 +32,11 @@ type FabricServiceToken struct {
 	// Either 'a_side' or 'z_side', depending on which type of Fabric VC was requested.
 	ServiceTokenType *string `json:"service_token_type,omitempty"`
 	// The state of the service token that corresponds with the service token state on Fabric. An 'inactive' state refers to a token that has not been redeemed yet on the Fabric side, an 'active' state refers to a token that has already been redeemed, and an 'expired' state refers to a token that has reached its expiry time.
-	State *string `json:"state,omitempty"`
+	State                *string `json:"state,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FabricServiceToken FabricServiceToken
 
 // NewFabricServiceToken instantiates a new FabricServiceToken object
 // This constructor will assign default values to properties that have it defined,
@@ -272,7 +275,34 @@ func (o FabricServiceToken) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.State) {
 		toSerialize["state"] = o.State
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FabricServiceToken) UnmarshalJSON(bytes []byte) (err error) {
+	varFabricServiceToken := _FabricServiceToken{}
+
+	if err = json.Unmarshal(bytes, &varFabricServiceToken); err == nil {
+		*o = FabricServiceToken(varFabricServiceToken)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "expires_at")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "max_allowed_speed")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "service_token_type")
+		delete(additionalProperties, "state")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFabricServiceToken struct {

--- a/metal/v1/model_facility.go
+++ b/metal/v1/model_facility.go
@@ -25,10 +25,13 @@ type Facility struct {
 	Features []string `json:"features,omitempty"`
 	Id       *string  `json:"id,omitempty"`
 	// IP ranges registered in facility. Can be used for GeoIP location
-	IpRanges []string     `json:"ip_ranges,omitempty"`
-	Metro    *DeviceMetro `json:"metro,omitempty"`
-	Name     *string      `json:"name,omitempty"`
+	IpRanges             []string     `json:"ip_ranges,omitempty"`
+	Metro                *DeviceMetro `json:"metro,omitempty"`
+	Name                 *string      `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Facility Facility
 
 // NewFacility instantiates a new Facility object
 // This constructor will assign default values to properties that have it defined,
@@ -302,7 +305,35 @@ func (o Facility) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Facility) UnmarshalJSON(bytes []byte) (err error) {
+	varFacility := _Facility{}
+
+	if err = json.Unmarshal(bytes, &varFacility); err == nil {
+		*o = Facility(varFacility)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "ip_ranges")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFacility struct {

--- a/metal/v1/model_facility_input.go
+++ b/metal/v1/model_facility_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &FacilityInput{}
 
 // FacilityInput struct for FacilityInput
 type FacilityInput struct {
-	Facility FacilityInputFacility `json:"facility"`
+	Facility             FacilityInputFacility `json:"facility"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FacilityInput FacilityInput
 
 // NewFacilityInput instantiates a new FacilityInput object
 // This constructor will assign default values to properties that have it defined,
@@ -76,7 +79,29 @@ func (o FacilityInput) MarshalJSON() ([]byte, error) {
 func (o FacilityInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["facility"] = o.Facility
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FacilityInput) UnmarshalJSON(bytes []byte) (err error) {
+	varFacilityInput := _FacilityInput{}
+
+	if err = json.Unmarshal(bytes, &varFacilityInput); err == nil {
+		*o = FacilityInput(varFacilityInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "facility")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFacilityInput struct {

--- a/metal/v1/model_facility_list.go
+++ b/metal/v1/model_facility_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &FacilityList{}
 
 // FacilityList struct for FacilityList
 type FacilityList struct {
-	Facilities []Facility `json:"facilities,omitempty"`
+	Facilities           []Facility `json:"facilities,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FacilityList FacilityList
 
 // NewFacilityList instantiates a new FacilityList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o FacilityList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Facilities) {
 		toSerialize["facilities"] = o.Facilities
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FacilityList) UnmarshalJSON(bytes []byte) (err error) {
+	varFacilityList := _FacilityList{}
+
+	if err = json.Unmarshal(bytes, &varFacilityList); err == nil {
+		*o = FacilityList(varFacilityList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "facilities")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFacilityList struct {

--- a/metal/v1/model_filesystem.go
+++ b/metal/v1/model_filesystem.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &Filesystem{}
 
 // Filesystem struct for Filesystem
 type Filesystem struct {
-	Mount *Mount `json:"mount,omitempty"`
+	Mount                *Mount `json:"mount,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Filesystem Filesystem
 
 // NewFilesystem instantiates a new Filesystem object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o Filesystem) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Mount) {
 		toSerialize["mount"] = o.Mount
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Filesystem) UnmarshalJSON(bytes []byte) (err error) {
+	varFilesystem := _Filesystem{}
+
+	if err = json.Unmarshal(bytes, &varFilesystem); err == nil {
+		*o = Filesystem(varFilesystem)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "mount")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFilesystem struct {

--- a/metal/v1/model_find_traffic_timeframe_parameter.go
+++ b/metal/v1/model_find_traffic_timeframe_parameter.go
@@ -21,9 +21,12 @@ var _ MappedNullable = &FindTrafficTimeframeParameter{}
 
 // FindTrafficTimeframeParameter struct for FindTrafficTimeframeParameter
 type FindTrafficTimeframeParameter struct {
-	EndedAt   time.Time `json:"ended_at"`
-	StartedAt time.Time `json:"started_at"`
+	EndedAt              time.Time `json:"ended_at"`
+	StartedAt            time.Time `json:"started_at"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FindTrafficTimeframeParameter FindTrafficTimeframeParameter
 
 // NewFindTrafficTimeframeParameter instantiates a new FindTrafficTimeframeParameter object
 // This constructor will assign default values to properties that have it defined,
@@ -104,7 +107,30 @@ func (o FindTrafficTimeframeParameter) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["ended_at"] = o.EndedAt
 	toSerialize["started_at"] = o.StartedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FindTrafficTimeframeParameter) UnmarshalJSON(bytes []byte) (err error) {
+	varFindTrafficTimeframeParameter := _FindTrafficTimeframeParameter{}
+
+	if err = json.Unmarshal(bytes, &varFindTrafficTimeframeParameter); err == nil {
+		*o = FindTrafficTimeframeParameter(varFindTrafficTimeframeParameter)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ended_at")
+		delete(additionalProperties, "started_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFindTrafficTimeframeParameter struct {

--- a/metal/v1/model_global_bgp_range.go
+++ b/metal/v1/model_global_bgp_range.go
@@ -20,12 +20,15 @@ var _ MappedNullable = &GlobalBgpRange{}
 
 // GlobalBgpRange struct for GlobalBgpRange
 type GlobalBgpRange struct {
-	AddressFamily *int32  `json:"address_family,omitempty"`
-	Href          *string `json:"href,omitempty"`
-	Id            *string `json:"id,omitempty"`
-	Project       *Href   `json:"project,omitempty"`
-	Range         *string `json:"range,omitempty"`
+	AddressFamily        *int32  `json:"address_family,omitempty"`
+	Href                 *string `json:"href,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Project              *Href   `json:"project,omitempty"`
+	Range                *string `json:"range,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _GlobalBgpRange GlobalBgpRange
 
 // NewGlobalBgpRange instantiates a new GlobalBgpRange object
 // This constructor will assign default values to properties that have it defined,
@@ -229,7 +232,33 @@ func (o GlobalBgpRange) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Range) {
 		toSerialize["range"] = o.Range
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *GlobalBgpRange) UnmarshalJSON(bytes []byte) (err error) {
+	varGlobalBgpRange := _GlobalBgpRange{}
+
+	if err = json.Unmarshal(bytes, &varGlobalBgpRange); err == nil {
+		*o = GlobalBgpRange(varGlobalBgpRange)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "range")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableGlobalBgpRange struct {

--- a/metal/v1/model_global_bgp_range_list.go
+++ b/metal/v1/model_global_bgp_range_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &GlobalBgpRangeList{}
 
 // GlobalBgpRangeList struct for GlobalBgpRangeList
 type GlobalBgpRangeList struct {
-	GlobalBgpRanges []GlobalBgpRange `json:"global_bgp_ranges,omitempty"`
+	GlobalBgpRanges      []GlobalBgpRange `json:"global_bgp_ranges,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _GlobalBgpRangeList GlobalBgpRangeList
 
 // NewGlobalBgpRangeList instantiates a new GlobalBgpRangeList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o GlobalBgpRangeList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.GlobalBgpRanges) {
 		toSerialize["global_bgp_ranges"] = o.GlobalBgpRanges
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *GlobalBgpRangeList) UnmarshalJSON(bytes []byte) (err error) {
+	varGlobalBgpRangeList := _GlobalBgpRangeList{}
+
+	if err = json.Unmarshal(bytes, &varGlobalBgpRangeList); err == nil {
+		*o = GlobalBgpRangeList(varGlobalBgpRangeList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "global_bgp_ranges")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableGlobalBgpRangeList struct {

--- a/metal/v1/model_hardware_reservation.go
+++ b/metal/v1/model_hardware_reservation.go
@@ -41,8 +41,11 @@ type HardwareReservation struct {
 	// Switch short id. This can be used to determine if two devices are connected to the same switch, for example.
 	SwitchUuid *string `json:"switch_uuid,omitempty"`
 	// Expiration date for the reservation.
-	TerminationTime *time.Time `json:"termination_time,omitempty"`
+	TerminationTime      *time.Time `json:"termination_time,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HardwareReservation HardwareReservation
 
 // NewHardwareReservation instantiates a new HardwareReservation object
 // This constructor will assign default values to properties that have it defined,
@@ -561,7 +564,42 @@ func (o HardwareReservation) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.TerminationTime) {
 		toSerialize["termination_time"] = o.TerminationTime
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *HardwareReservation) UnmarshalJSON(bytes []byte) (err error) {
+	varHardwareReservation := _HardwareReservation{}
+
+	if err = json.Unmarshal(bytes, &varHardwareReservation); err == nil {
+		*o = HardwareReservation(varHardwareReservation)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "custom_rate")
+		delete(additionalProperties, "device")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "need_of_service")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "provisionable")
+		delete(additionalProperties, "short_id")
+		delete(additionalProperties, "spare")
+		delete(additionalProperties, "switch_uuid")
+		delete(additionalProperties, "termination_time")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHardwareReservation struct {

--- a/metal/v1/model_hardware_reservation_list.go
+++ b/metal/v1/model_hardware_reservation_list.go
@@ -22,7 +22,10 @@ var _ MappedNullable = &HardwareReservationList{}
 type HardwareReservationList struct {
 	HardwareReservations []HardwareReservation `json:"hardware_reservations,omitempty"`
 	Meta                 *Meta                 `json:"meta,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HardwareReservationList HardwareReservationList
 
 // NewHardwareReservationList instantiates a new HardwareReservationList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o HardwareReservationList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Meta) {
 		toSerialize["meta"] = o.Meta
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *HardwareReservationList) UnmarshalJSON(bytes []byte) (err error) {
+	varHardwareReservationList := _HardwareReservationList{}
+
+	if err = json.Unmarshal(bytes, &varHardwareReservationList); err == nil {
+		*o = HardwareReservationList(varHardwareReservationList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "hardware_reservations")
+		delete(additionalProperties, "meta")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHardwareReservationList struct {

--- a/metal/v1/model_href.go
+++ b/metal/v1/model_href.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &Href{}
 
 // Href struct for Href
 type Href struct {
-	Href string `json:"href"`
+	Href                 string `json:"href"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Href Href
 
 // NewHref instantiates a new Href object
 // This constructor will assign default values to properties that have it defined,
@@ -76,7 +79,29 @@ func (o Href) MarshalJSON() ([]byte, error) {
 func (o Href) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["href"] = o.Href
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Href) UnmarshalJSON(bytes []byte) (err error) {
+	varHref := _Href{}
+
+	if err = json.Unmarshal(bytes, &varHref); err == nil {
+		*o = Href(varHref)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "href")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHref struct {

--- a/metal/v1/model_instances_batch_create_input.go
+++ b/metal/v1/model_instances_batch_create_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &InstancesBatchCreateInput{}
 
 // InstancesBatchCreateInput struct for InstancesBatchCreateInput
 type InstancesBatchCreateInput struct {
-	Batches []InstancesBatchCreateInputBatchesInner `json:"batches,omitempty"`
+	Batches              []InstancesBatchCreateInputBatchesInner `json:"batches,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InstancesBatchCreateInput InstancesBatchCreateInput
 
 // NewInstancesBatchCreateInput instantiates a new InstancesBatchCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o InstancesBatchCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Batches) {
 		toSerialize["batches"] = o.Batches
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InstancesBatchCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varInstancesBatchCreateInput := _InstancesBatchCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varInstancesBatchCreateInput); err == nil {
+		*o = InstancesBatchCreateInput(varInstancesBatchCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "batches")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInstancesBatchCreateInput struct {

--- a/metal/v1/model_instances_batch_create_input_batches_inner.go
+++ b/metal/v1/model_instances_batch_create_input_batches_inner.go
@@ -69,9 +69,12 @@ type InstancesBatchCreateInputBatchesInner struct {
 	// A list of UUIDs identifying the users that should be authorized to access this device (typically via /root/.ssh/authorized_keys).  These keys will also appear in the device metadata.  The users must be members of the project or organization.  If no SSH keys are specified (`user_ssh_keys`, `project_ssh_keys`, and `ssh_keys` are all empty lists or omitted), all parent project keys, parent project members keys and organization members keys will be included. This behaviour can be changed with 'no_ssh_keys' option to omit any SSH key being added.
 	UserSshKeys []string `json:"user_ssh_keys,omitempty"`
 	// The userdata presented in the metadata service for this device.  Userdata is fetched and interpreted by the operating system installed on the device. Acceptable formats are determined by the operating system, with the exception of a special iPXE enabling syntax which is handled before the operating system starts.  See [Server User Data](https://metal.equinix.com/developers/docs/servers/user-data/) and [Provisioning with Custom iPXE](https://metal.equinix.com/developers/docs/operating-systems/custom-ipxe/#provisioning-with-custom-ipxe) for more details.
-	Userdata *string               `json:"userdata,omitempty"`
-	Facility FacilityInputFacility `json:"facility"`
+	Userdata             *string               `json:"userdata,omitempty"`
+	Facility             FacilityInputFacility `json:"facility"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InstancesBatchCreateInputBatchesInner InstancesBatchCreateInputBatchesInner
 
 // NewInstancesBatchCreateInputBatchesInner instantiates a new InstancesBatchCreateInputBatchesInner object
 // This constructor will assign default values to properties that have it defined,
@@ -1033,7 +1036,55 @@ func (o InstancesBatchCreateInputBatchesInner) ToMap() (map[string]interface{}, 
 		toSerialize["userdata"] = o.Userdata
 	}
 	toSerialize["facility"] = o.Facility
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InstancesBatchCreateInputBatchesInner) UnmarshalJSON(bytes []byte) (err error) {
+	varInstancesBatchCreateInputBatchesInner := _InstancesBatchCreateInputBatchesInner{}
+
+	if err = json.Unmarshal(bytes, &varInstancesBatchCreateInputBatchesInner); err == nil {
+		*o = InstancesBatchCreateInputBatchesInner(varInstancesBatchCreateInputBatchesInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "hostnames")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "hardware_reservation_id")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "ip_addresses")
+		delete(additionalProperties, "ipxe_script_url")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "no_ssh_keys")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "private_ipv4_subnet_size")
+		delete(additionalProperties, "project_ssh_keys")
+		delete(additionalProperties, "public_ipv4_subnet_size")
+		delete(additionalProperties, "spot_instance")
+		delete(additionalProperties, "spot_price_max")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "termination_time")
+		delete(additionalProperties, "user_ssh_keys")
+		delete(additionalProperties, "userdata")
+		delete(additionalProperties, "facility")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInstancesBatchCreateInputBatchesInner struct {

--- a/metal/v1/model_instances_batch_create_input_batches_inner_all_of.go
+++ b/metal/v1/model_instances_batch_create_input_batches_inner_all_of.go
@@ -22,8 +22,11 @@ var _ MappedNullable = &InstancesBatchCreateInputBatchesInnerAllOf{}
 type InstancesBatchCreateInputBatchesInnerAllOf struct {
 	Hostnames []string `json:"hostnames,omitempty"`
 	// The number of devices to create in this batch. The hostname may contain an `{{index}}` placeholder, which will be replaced with the index of the device in the batch. For example, if the hostname is `device-{{index}}`, the first device in the batch will have the hostname `device-01`, the second device will have the hostname `device-02`, and so on.
-	Quantity *int32 `json:"quantity,omitempty"`
+	Quantity             *int32 `json:"quantity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InstancesBatchCreateInputBatchesInnerAllOf InstancesBatchCreateInputBatchesInnerAllOf
 
 // NewInstancesBatchCreateInputBatchesInnerAllOf instantiates a new InstancesBatchCreateInputBatchesInnerAllOf object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,30 @@ func (o InstancesBatchCreateInputBatchesInnerAllOf) ToMap() (map[string]interfac
 	if !isNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InstancesBatchCreateInputBatchesInnerAllOf) UnmarshalJSON(bytes []byte) (err error) {
+	varInstancesBatchCreateInputBatchesInnerAllOf := _InstancesBatchCreateInputBatchesInnerAllOf{}
+
+	if err = json.Unmarshal(bytes, &varInstancesBatchCreateInputBatchesInnerAllOf); err == nil {
+		*o = InstancesBatchCreateInputBatchesInnerAllOf(varInstancesBatchCreateInputBatchesInnerAllOf)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "hostnames")
+		delete(additionalProperties, "quantity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInstancesBatchCreateInputBatchesInnerAllOf struct {

--- a/metal/v1/model_interconnection.go
+++ b/metal/v1/model_interconnection.go
@@ -43,11 +43,14 @@ type Interconnection struct {
 	// This token is used for shared interconnections to be used as the Fabric Token. This field is entirely deprecated.
 	Token *string `json:"token,omitempty"`
 	// The 'shared' type of interconnection refers to shared connections, or later also known as Fabric Virtual Connections (or Fabric VCs). The 'dedicated' type of interconnection refers to interconnections created with Dedicated Ports.
-	Type        *string    `json:"type,omitempty"`
-	CreatedAt   *time.Time `json:"created_at,omitempty"`
-	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
-	RequestedBy *Href      `json:"requested_by,omitempty"`
+	Type                 *string    `json:"type,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	RequestedBy          *Href      `json:"requested_by,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Interconnection Interconnection
 
 // NewInterconnection instantiates a new Interconnection object
 // This constructor will assign default values to properties that have it defined,
@@ -741,7 +744,47 @@ func (o Interconnection) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.RequestedBy) {
 		toSerialize["requested_by"] = o.RequestedBy
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Interconnection) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnection := _Interconnection{}
+
+	if err = json.Unmarshal(bytes, &varInterconnection); err == nil {
+		*o = Interconnection(varInterconnection)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "contact_email")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "mode")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "organization")
+		delete(additionalProperties, "ports")
+		delete(additionalProperties, "redundancy")
+		delete(additionalProperties, "service_tokens")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "token")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "requested_by")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnection struct {

--- a/metal/v1/model_interconnection_create_input.go
+++ b/metal/v1/model_interconnection_create_input.go
@@ -40,8 +40,11 @@ type InterconnectionCreateInput struct {
 	// A list of one or two metro-based VLANs that will be set on the virtual circuits of primary and/or secondary (if redundant) interconnections respectively when creating Fabric VCs. VLANs can also be set after the interconnection is created, but are required to fully activate the interconnection. This parameter is included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
 	Vlans []int32 `json:"vlans,omitempty"`
 	// Can only be set when creating Fabric VCs in VRF(s). This field holds a list of VRF UUIDs that will be set automatically on the virtual circuits on creation, and can hold up to two UUIDs. Two UUIDs are required when requesting redundant Fabric VCs. The first UUID will be set on the primary virtual circuit, while the second UUID will be set on the secondary. The two UUIDs can be the same if both the primary and secondary virtual circuits will be in the same VRF. This parameter is included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
-	Vrfs []string `json:"vrfs,omitempty"`
+	Vrfs                 []string `json:"vrfs,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InterconnectionCreateInput InterconnectionCreateInput
 
 // NewInterconnectionCreateInput instantiates a new InterconnectionCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -489,7 +492,41 @@ func (o InterconnectionCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vrfs) {
 		toSerialize["vrfs"] = o.Vrfs
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InterconnectionCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnectionCreateInput := _InterconnectionCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varInterconnectionCreateInput); err == nil {
+		*o = InterconnectionCreateInput(varInterconnectionCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "contact_email")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "mode")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "redundancy")
+		delete(additionalProperties, "service_token_type")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "vlans")
+		delete(additionalProperties, "vrfs")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnectionCreateInput struct {

--- a/metal/v1/model_interconnection_list.go
+++ b/metal/v1/model_interconnection_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &InterconnectionList{}
 
 // InterconnectionList struct for InterconnectionList
 type InterconnectionList struct {
-	Interconnections []Interconnection `json:"interconnections,omitempty"`
+	Interconnections     []Interconnection `json:"interconnections,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InterconnectionList InterconnectionList
 
 // NewInterconnectionList instantiates a new InterconnectionList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o InterconnectionList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Interconnections) {
 		toSerialize["interconnections"] = o.Interconnections
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InterconnectionList) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnectionList := _InterconnectionList{}
+
+	if err = json.Unmarshal(bytes, &varInterconnectionList); err == nil {
+		*o = InterconnectionList(varInterconnectionList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "interconnections")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnectionList struct {

--- a/metal/v1/model_interconnection_metro.go
+++ b/metal/v1/model_interconnection_metro.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &InterconnectionMetro{}
 
 // InterconnectionMetro The location of where the shared or Dedicated Port is located. For interconnections with Dedicated Ports,   this will be the location of the Dedicated Ports. For Fabric VCs (Metal Billed), this is where interconnection will be originating from, as we pre-authorize the use of one of our shared ports   as the origin of the interconnection using A-Side service tokens. We only allow local connections for Fabric VCs (Metal Billed), so the destination location must be the same as the origin. For Fabric VCs (Fabric Billed),    this will be the destination of the interconnection. We allow remote connections for Fabric VCs (Fabric Billed), so the origin of the interconnection can be a different metro set here.
 type InterconnectionMetro struct {
-	Code    *string `json:"code,omitempty"`
-	Country *string `json:"country,omitempty"`
-	Id      *string `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
+	Code                 *string `json:"code,omitempty"`
+	Country              *string `json:"country,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InterconnectionMetro InterconnectionMetro
 
 // NewInterconnectionMetro instantiates a new InterconnectionMetro object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o InterconnectionMetro) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InterconnectionMetro) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnectionMetro := _InterconnectionMetro{}
+
+	if err = json.Unmarshal(bytes, &varInterconnectionMetro); err == nil {
+		*o = InterconnectionMetro(varInterconnectionMetro)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnectionMetro struct {

--- a/metal/v1/model_interconnection_port.go
+++ b/metal/v1/model_interconnection_port.go
@@ -27,13 +27,16 @@ type InterconnectionPort struct {
 	// For both Fabric VCs and Dedicated Ports, this will be 'requested' on creation and 'deleting' on deletion. Once the Fabric VC has found its corresponding Fabric connection, this will turn to 'active'. For Dedicated Ports, once the dedicated port is associated, this will also turn to 'active'. For Fabric VCs, this can turn into an 'expired' state if the service token associated is expired.
 	Status *string `json:"status,omitempty"`
 	// A switch 'short ID'
-	SwitchId        *string             `json:"switch_id,omitempty"`
-	VirtualCircuits *VirtualCircuitList `json:"virtual_circuits,omitempty"`
-	Name            *string             `json:"name,omitempty"`
-	Speed           *int32              `json:"speed,omitempty"`
-	LinkStatus      *string             `json:"link_status,omitempty"`
-	Href            *string             `json:"href,omitempty"`
+	SwitchId             *string             `json:"switch_id,omitempty"`
+	VirtualCircuits      *VirtualCircuitList `json:"virtual_circuits,omitempty"`
+	Name                 *string             `json:"name,omitempty"`
+	Speed                *int32              `json:"speed,omitempty"`
+	LinkStatus           *string             `json:"link_status,omitempty"`
+	Href                 *string             `json:"href,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InterconnectionPort InterconnectionPort
 
 // NewInterconnectionPort instantiates a new InterconnectionPort object
 // This constructor will assign default values to properties that have it defined,
@@ -412,7 +415,38 @@ func (o InterconnectionPort) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Href) {
 		toSerialize["href"] = o.Href
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InterconnectionPort) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnectionPort := _InterconnectionPort{}
+
+	if err = json.Unmarshal(bytes, &varInterconnectionPort); err == nil {
+		*o = InterconnectionPort(varInterconnectionPort)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "organization")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "switch_id")
+		delete(additionalProperties, "virtual_circuits")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "link_status")
+		delete(additionalProperties, "href")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnectionPort struct {

--- a/metal/v1/model_interconnection_port_list.go
+++ b/metal/v1/model_interconnection_port_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &InterconnectionPortList{}
 
 // InterconnectionPortList struct for InterconnectionPortList
 type InterconnectionPortList struct {
-	Ports []InterconnectionPort `json:"ports,omitempty"`
+	Ports                []InterconnectionPort `json:"ports,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InterconnectionPortList InterconnectionPortList
 
 // NewInterconnectionPortList instantiates a new InterconnectionPortList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o InterconnectionPortList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Ports) {
 		toSerialize["ports"] = o.Ports
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InterconnectionPortList) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnectionPortList := _InterconnectionPortList{}
+
+	if err = json.Unmarshal(bytes, &varInterconnectionPortList); err == nil {
+		*o = InterconnectionPortList(varInterconnectionPortList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ports")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnectionPortList struct {

--- a/metal/v1/model_interconnection_update_input.go
+++ b/metal/v1/model_interconnection_update_input.go
@@ -26,9 +26,12 @@ type InterconnectionUpdateInput struct {
 	Mode *string `json:"mode,omitempty"`
 	Name *string `json:"name,omitempty"`
 	// Updating from 'redundant' to 'primary' will remove a secondary port, while updating from 'primary' to 'redundant' will add one.
-	Redundancy *string  `json:"redundancy,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
+	Redundancy           *string  `json:"redundancy,omitempty"`
+	Tags                 []string `json:"tags,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InterconnectionUpdateInput InterconnectionUpdateInput
 
 // NewInterconnectionUpdateInput instantiates a new InterconnectionUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -267,7 +270,34 @@ func (o InterconnectionUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InterconnectionUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varInterconnectionUpdateInput := _InterconnectionUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varInterconnectionUpdateInput); err == nil {
+		*o = InterconnectionUpdateInput(varInterconnectionUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "contact_email")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "mode")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "redundancy")
+		delete(additionalProperties, "tags")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInterconnectionUpdateInput struct {

--- a/metal/v1/model_invitation.go
+++ b/metal/v1/model_invitation.go
@@ -21,18 +21,21 @@ var _ MappedNullable = &Invitation{}
 
 // Invitation struct for Invitation
 type Invitation struct {
-	CreatedAt    *time.Time `json:"created_at,omitempty"`
-	Href         *string    `json:"href,omitempty"`
-	Id           *string    `json:"id,omitempty"`
-	Invitation   *Href      `json:"invitation,omitempty"`
-	InvitedBy    *Href      `json:"invited_by,omitempty"`
-	Invitee      *string    `json:"invitee,omitempty"`
-	Nonce        *string    `json:"nonce,omitempty"`
-	Organization *Href      `json:"organization,omitempty"`
-	Projects     []Href     `json:"projects,omitempty"`
-	Roles        []string   `json:"roles,omitempty"`
-	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	Href                 *string    `json:"href,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Invitation           *Href      `json:"invitation,omitempty"`
+	InvitedBy            *Href      `json:"invited_by,omitempty"`
+	Invitee              *string    `json:"invitee,omitempty"`
+	Nonce                *string    `json:"nonce,omitempty"`
+	Organization         *Href      `json:"organization,omitempty"`
+	Projects             []Href     `json:"projects,omitempty"`
+	Roles                []string   `json:"roles,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Invitation Invitation
 
 // NewInvitation instantiates a new Invitation object
 // This constructor will assign default values to properties that have it defined,
@@ -446,7 +449,39 @@ func (o Invitation) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Invitation) UnmarshalJSON(bytes []byte) (err error) {
+	varInvitation := _Invitation{}
+
+	if err = json.Unmarshal(bytes, &varInvitation); err == nil {
+		*o = Invitation(varInvitation)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "invitation")
+		delete(additionalProperties, "invited_by")
+		delete(additionalProperties, "invitee")
+		delete(additionalProperties, "nonce")
+		delete(additionalProperties, "organization")
+		delete(additionalProperties, "projects")
+		delete(additionalProperties, "roles")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInvitation struct {

--- a/metal/v1/model_invitation_input.go
+++ b/metal/v1/model_invitation_input.go
@@ -20,12 +20,15 @@ var _ MappedNullable = &InvitationInput{}
 
 // InvitationInput struct for InvitationInput
 type InvitationInput struct {
-	Invitee        string   `json:"invitee"`
-	Message        *string  `json:"message,omitempty"`
-	OrganizationId *string  `json:"organization_id,omitempty"`
-	ProjectsIds    []string `json:"projects_ids,omitempty"`
-	Roles          []string `json:"roles,omitempty"`
+	Invitee              string   `json:"invitee"`
+	Message              *string  `json:"message,omitempty"`
+	OrganizationId       *string  `json:"organization_id,omitempty"`
+	ProjectsIds          []string `json:"projects_ids,omitempty"`
+	Roles                []string `json:"roles,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InvitationInput InvitationInput
 
 // NewInvitationInput instantiates a new InvitationInput object
 // This constructor will assign default values to properties that have it defined,
@@ -220,7 +223,33 @@ func (o InvitationInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Roles) {
 		toSerialize["roles"] = o.Roles
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InvitationInput) UnmarshalJSON(bytes []byte) (err error) {
+	varInvitationInput := _InvitationInput{}
+
+	if err = json.Unmarshal(bytes, &varInvitationInput); err == nil {
+		*o = InvitationInput(varInvitationInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "invitee")
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "organization_id")
+		delete(additionalProperties, "projects_ids")
+		delete(additionalProperties, "roles")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInvitationInput struct {

--- a/metal/v1/model_invitation_list.go
+++ b/metal/v1/model_invitation_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &InvitationList{}
 
 // InvitationList struct for InvitationList
 type InvitationList struct {
-	Invitations []Membership `json:"invitations,omitempty"`
+	Invitations          []Membership `json:"invitations,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InvitationList InvitationList
 
 // NewInvitationList instantiates a new InvitationList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o InvitationList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Invitations) {
 		toSerialize["invitations"] = o.Invitations
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InvitationList) UnmarshalJSON(bytes []byte) (err error) {
+	varInvitationList := _InvitationList{}
+
+	if err = json.Unmarshal(bytes, &varInvitationList); err == nil {
+		*o = InvitationList(varInvitationList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "invitations")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInvitationList struct {

--- a/metal/v1/model_ip_assignment.go
+++ b/metal/v1/model_ip_assignment.go
@@ -21,24 +21,27 @@ var _ MappedNullable = &IPAssignment{}
 
 // IPAssignment struct for IPAssignment
 type IPAssignment struct {
-	Address       *string            `json:"address,omitempty"`
-	AddressFamily *int32             `json:"address_family,omitempty"`
-	AssignedTo    *Href              `json:"assigned_to,omitempty"`
-	Cidr          *int32             `json:"cidr,omitempty"`
-	CreatedAt     *time.Time         `json:"created_at,omitempty"`
-	Enabled       *bool              `json:"enabled,omitempty"`
-	Gateway       *string            `json:"gateway,omitempty"`
-	GlobalIp      *bool              `json:"global_ip,omitempty"`
-	Href          *string            `json:"href,omitempty"`
-	Id            *string            `json:"id,omitempty"`
-	Manageable    *bool              `json:"manageable,omitempty"`
-	Management    *bool              `json:"management,omitempty"`
-	Metro         *IPAssignmentMetro `json:"metro,omitempty"`
-	Netmask       *string            `json:"netmask,omitempty"`
-	Network       *string            `json:"network,omitempty"`
-	ParentBlock   *ParentBlock       `json:"parent_block,omitempty"`
-	Public        *bool              `json:"public,omitempty"`
+	Address              *string            `json:"address,omitempty"`
+	AddressFamily        *int32             `json:"address_family,omitempty"`
+	AssignedTo           *Href              `json:"assigned_to,omitempty"`
+	Cidr                 *int32             `json:"cidr,omitempty"`
+	CreatedAt            *time.Time         `json:"created_at,omitempty"`
+	Enabled              *bool              `json:"enabled,omitempty"`
+	Gateway              *string            `json:"gateway,omitempty"`
+	GlobalIp             *bool              `json:"global_ip,omitempty"`
+	Href                 *string            `json:"href,omitempty"`
+	Id                   *string            `json:"id,omitempty"`
+	Manageable           *bool              `json:"manageable,omitempty"`
+	Management           *bool              `json:"management,omitempty"`
+	Metro                *IPAssignmentMetro `json:"metro,omitempty"`
+	Netmask              *string            `json:"netmask,omitempty"`
+	Network              *string            `json:"network,omitempty"`
+	ParentBlock          *ParentBlock       `json:"parent_block,omitempty"`
+	Public               *bool              `json:"public,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPAssignment IPAssignment
 
 // NewIPAssignment instantiates a new IPAssignment object
 // This constructor will assign default values to properties that have it defined,
@@ -662,7 +665,45 @@ func (o IPAssignment) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Public) {
 		toSerialize["public"] = o.Public
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPAssignment) UnmarshalJSON(bytes []byte) (err error) {
+	varIPAssignment := _IPAssignment{}
+
+	if err = json.Unmarshal(bytes, &varIPAssignment); err == nil {
+		*o = IPAssignment(varIPAssignment)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "assigned_to")
+		delete(additionalProperties, "cidr")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "enabled")
+		delete(additionalProperties, "gateway")
+		delete(additionalProperties, "global_ip")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "manageable")
+		delete(additionalProperties, "management")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "netmask")
+		delete(additionalProperties, "network")
+		delete(additionalProperties, "parent_block")
+		delete(additionalProperties, "public")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPAssignment struct {

--- a/metal/v1/model_ip_assignment_input.go
+++ b/metal/v1/model_ip_assignment_input.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &IPAssignmentInput{}
 
 // IPAssignmentInput struct for IPAssignmentInput
 type IPAssignmentInput struct {
-	Address    string                 `json:"address"`
-	Customdata map[string]interface{} `json:"customdata,omitempty"`
+	Address              string                 `json:"address"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPAssignmentInput IPAssignmentInput
 
 // NewIPAssignmentInput instantiates a new IPAssignmentInput object
 // This constructor will assign default values to properties that have it defined,
@@ -112,7 +115,30 @@ func (o IPAssignmentInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Customdata) {
 		toSerialize["customdata"] = o.Customdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPAssignmentInput) UnmarshalJSON(bytes []byte) (err error) {
+	varIPAssignmentInput := _IPAssignmentInput{}
+
+	if err = json.Unmarshal(bytes, &varIPAssignmentInput); err == nil {
+		*o = IPAssignmentInput(varIPAssignmentInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "customdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPAssignmentInput struct {

--- a/metal/v1/model_ip_assignment_list.go
+++ b/metal/v1/model_ip_assignment_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &IPAssignmentList{}
 
 // IPAssignmentList struct for IPAssignmentList
 type IPAssignmentList struct {
-	IpAddresses []IPAssignment `json:"ip_addresses,omitempty"`
+	IpAddresses          []IPAssignment `json:"ip_addresses,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPAssignmentList IPAssignmentList
 
 // NewIPAssignmentList instantiates a new IPAssignmentList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o IPAssignmentList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.IpAddresses) {
 		toSerialize["ip_addresses"] = o.IpAddresses
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPAssignmentList) UnmarshalJSON(bytes []byte) (err error) {
+	varIPAssignmentList := _IPAssignmentList{}
+
+	if err = json.Unmarshal(bytes, &varIPAssignmentList); err == nil {
+		*o = IPAssignmentList(varIPAssignmentList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ip_addresses")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPAssignmentList struct {

--- a/metal/v1/model_ip_assignment_metro.go
+++ b/metal/v1/model_ip_assignment_metro.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &IPAssignmentMetro{}
 
 // IPAssignmentMetro struct for IPAssignmentMetro
 type IPAssignmentMetro struct {
-	Code    *string `json:"code,omitempty"`
-	Country *string `json:"country,omitempty"`
-	Id      *string `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
+	Code                 *string `json:"code,omitempty"`
+	Country              *string `json:"country,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPAssignmentMetro IPAssignmentMetro
 
 // NewIPAssignmentMetro instantiates a new IPAssignmentMetro object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o IPAssignmentMetro) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPAssignmentMetro) UnmarshalJSON(bytes []byte) (err error) {
+	varIPAssignmentMetro := _IPAssignmentMetro{}
+
+	if err = json.Unmarshal(bytes, &varIPAssignmentMetro); err == nil {
+		*o = IPAssignmentMetro(varIPAssignmentMetro)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPAssignmentMetro struct {

--- a/metal/v1/model_ip_assignment_update_input.go
+++ b/metal/v1/model_ip_assignment_update_input.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &IPAssignmentUpdateInput{}
 
 // IPAssignmentUpdateInput struct for IPAssignmentUpdateInput
 type IPAssignmentUpdateInput struct {
-	Details    *string                `json:"details,omitempty"`
-	Customdata map[string]interface{} `json:"customdata,omitempty"`
-	Tags       []string               `json:"tags,omitempty"`
+	Details              *string                `json:"details,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Tags                 []string               `json:"tags,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPAssignmentUpdateInput IPAssignmentUpdateInput
 
 // NewIPAssignmentUpdateInput instantiates a new IPAssignmentUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o IPAssignmentUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPAssignmentUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varIPAssignmentUpdateInput := _IPAssignmentUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varIPAssignmentUpdateInput); err == nil {
+		*o = IPAssignmentUpdateInput(varIPAssignmentUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "details")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "tags")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPAssignmentUpdateInput struct {

--- a/metal/v1/model_ip_availabilities_list.go
+++ b/metal/v1/model_ip_availabilities_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &IPAvailabilitiesList{}
 
 // IPAvailabilitiesList struct for IPAvailabilitiesList
 type IPAvailabilitiesList struct {
-	Available []string `json:"available,omitempty"`
+	Available            []string `json:"available,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPAvailabilitiesList IPAvailabilitiesList
 
 // NewIPAvailabilitiesList instantiates a new IPAvailabilitiesList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o IPAvailabilitiesList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Available) {
 		toSerialize["available"] = o.Available
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPAvailabilitiesList) UnmarshalJSON(bytes []byte) (err error) {
+	varIPAvailabilitiesList := _IPAvailabilitiesList{}
+
+	if err = json.Unmarshal(bytes, &varIPAvailabilitiesList); err == nil {
+		*o = IPAvailabilitiesList(varIPAvailabilitiesList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "available")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPAvailabilitiesList struct {

--- a/metal/v1/model_ip_reservation_facility.go
+++ b/metal/v1/model_ip_reservation_facility.go
@@ -25,10 +25,13 @@ type IPReservationFacility struct {
 	Features []string `json:"features,omitempty"`
 	Id       *string  `json:"id,omitempty"`
 	// IP ranges registered in facility. Can be used for GeoIP location
-	IpRanges []string     `json:"ip_ranges,omitempty"`
-	Metro    *DeviceMetro `json:"metro,omitempty"`
-	Name     *string      `json:"name,omitempty"`
+	IpRanges             []string     `json:"ip_ranges,omitempty"`
+	Metro                *DeviceMetro `json:"metro,omitempty"`
+	Name                 *string      `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPReservationFacility IPReservationFacility
 
 // NewIPReservationFacility instantiates a new IPReservationFacility object
 // This constructor will assign default values to properties that have it defined,
@@ -302,7 +305,35 @@ func (o IPReservationFacility) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPReservationFacility) UnmarshalJSON(bytes []byte) (err error) {
+	varIPReservationFacility := _IPReservationFacility{}
+
+	if err = json.Unmarshal(bytes, &varIPReservationFacility); err == nil {
+		*o = IPReservationFacility(varIPReservationFacility)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "ip_ranges")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPReservationFacility struct {

--- a/metal/v1/model_ip_reservation_list.go
+++ b/metal/v1/model_ip_reservation_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &IPReservationList{}
 
 // IPReservationList struct for IPReservationList
 type IPReservationList struct {
-	IpAddresses []IPReservationListIpAddressesInner `json:"ip_addresses,omitempty"`
+	IpAddresses          []IPReservationListIpAddressesInner `json:"ip_addresses,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPReservationList IPReservationList
 
 // NewIPReservationList instantiates a new IPReservationList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o IPReservationList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.IpAddresses) {
 		toSerialize["ip_addresses"] = o.IpAddresses
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPReservationList) UnmarshalJSON(bytes []byte) (err error) {
+	varIPReservationList := _IPReservationList{}
+
+	if err = json.Unmarshal(bytes, &varIPReservationList); err == nil {
+		*o = IPReservationList(varIPReservationList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ip_addresses")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPReservationList struct {

--- a/metal/v1/model_ip_reservation_metro.go
+++ b/metal/v1/model_ip_reservation_metro.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &IPReservationMetro{}
 
 // IPReservationMetro struct for IPReservationMetro
 type IPReservationMetro struct {
-	Code    *string `json:"code,omitempty"`
-	Country *string `json:"country,omitempty"`
-	Id      *string `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
+	Code                 *string `json:"code,omitempty"`
+	Country              *string `json:"country,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPReservationMetro IPReservationMetro
 
 // NewIPReservationMetro instantiates a new IPReservationMetro object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o IPReservationMetro) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPReservationMetro) UnmarshalJSON(bytes []byte) (err error) {
+	varIPReservationMetro := _IPReservationMetro{}
+
+	if err = json.Unmarshal(bytes, &varIPReservationMetro); err == nil {
+		*o = IPReservationMetro(varIPReservationMetro)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPReservationMetro struct {

--- a/metal/v1/model_ip_reservation_request_input.go
+++ b/metal/v1/model_ip_reservation_request_input.go
@@ -26,11 +26,14 @@ type IPReservationRequestInput struct {
 	Facility               *string                `json:"facility,omitempty"`
 	FailOnApprovalRequired *bool                  `json:"fail_on_approval_required,omitempty"`
 	// The code of the metro you are requesting the IP reservation in.
-	Metro    *string  `json:"metro,omitempty"`
-	Quantity int32    `json:"quantity"`
-	Tags     []string `json:"tags,omitempty"`
-	Type     string   `json:"type"`
+	Metro                *string  `json:"metro,omitempty"`
+	Quantity             int32    `json:"quantity"`
+	Tags                 []string `json:"tags,omitempty"`
+	Type                 string   `json:"type"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IPReservationRequestInput IPReservationRequestInput
 
 // NewIPReservationRequestInput instantiates a new IPReservationRequestInput object
 // This constructor will assign default values to properties that have it defined,
@@ -356,7 +359,37 @@ func (o IPReservationRequestInput) ToMap() (map[string]interface{}, error) {
 		toSerialize["tags"] = o.Tags
 	}
 	toSerialize["type"] = o.Type
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IPReservationRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	varIPReservationRequestInput := _IPReservationRequestInput{}
+
+	if err = json.Unmarshal(bytes, &varIPReservationRequestInput); err == nil {
+		*o = IPReservationRequestInput(varIPReservationRequestInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "comments")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "details")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "fail_on_approval_required")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "type")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIPReservationRequestInput struct {

--- a/metal/v1/model_license.go
+++ b/metal/v1/model_license.go
@@ -20,13 +20,16 @@ var _ MappedNullable = &License{}
 
 // License struct for License
 type License struct {
-	Description     *string  `json:"description,omitempty"`
-	Id              *string  `json:"id,omitempty"`
-	LicenseKey      *string  `json:"license_key,omitempty"`
-	LicenseeProduct *Href    `json:"licensee_product,omitempty"`
-	Project         *Href    `json:"project,omitempty"`
-	Size            *float32 `json:"size,omitempty"`
+	Description          *string  `json:"description,omitempty"`
+	Id                   *string  `json:"id,omitempty"`
+	LicenseKey           *string  `json:"license_key,omitempty"`
+	LicenseeProduct      *Href    `json:"licensee_product,omitempty"`
+	Project              *Href    `json:"project,omitempty"`
+	Size                 *float32 `json:"size,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _License License
 
 // NewLicense instantiates a new License object
 // This constructor will assign default values to properties that have it defined,
@@ -265,7 +268,34 @@ func (o License) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Size) {
 		toSerialize["size"] = o.Size
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *License) UnmarshalJSON(bytes []byte) (err error) {
+	varLicense := _License{}
+
+	if err = json.Unmarshal(bytes, &varLicense); err == nil {
+		*o = License(varLicense)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "license_key")
+		delete(additionalProperties, "licensee_product")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "size")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableLicense struct {

--- a/metal/v1/model_license_create_input.go
+++ b/metal/v1/model_license_create_input.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &LicenseCreateInput{}
 
 // LicenseCreateInput struct for LicenseCreateInput
 type LicenseCreateInput struct {
-	Description       *string  `json:"description,omitempty"`
-	LicenseeProductId *string  `json:"licensee_product_id,omitempty"`
-	Size              *float32 `json:"size,omitempty"`
+	Description          *string  `json:"description,omitempty"`
+	LicenseeProductId    *string  `json:"licensee_product_id,omitempty"`
+	Size                 *float32 `json:"size,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _LicenseCreateInput LicenseCreateInput
 
 // NewLicenseCreateInput instantiates a new LicenseCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o LicenseCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Size) {
 		toSerialize["size"] = o.Size
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *LicenseCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varLicenseCreateInput := _LicenseCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varLicenseCreateInput); err == nil {
+		*o = LicenseCreateInput(varLicenseCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "licensee_product_id")
+		delete(additionalProperties, "size")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableLicenseCreateInput struct {

--- a/metal/v1/model_license_list.go
+++ b/metal/v1/model_license_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &LicenseList{}
 
 // LicenseList struct for LicenseList
 type LicenseList struct {
-	Licenses []License `json:"licenses,omitempty"`
+	Licenses             []License `json:"licenses,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _LicenseList LicenseList
 
 // NewLicenseList instantiates a new LicenseList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o LicenseList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Licenses) {
 		toSerialize["licenses"] = o.Licenses
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *LicenseList) UnmarshalJSON(bytes []byte) (err error) {
+	varLicenseList := _LicenseList{}
+
+	if err = json.Unmarshal(bytes, &varLicenseList); err == nil {
+		*o = LicenseList(varLicenseList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "licenses")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableLicenseList struct {

--- a/metal/v1/model_license_update_input.go
+++ b/metal/v1/model_license_update_input.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &LicenseUpdateInput{}
 
 // LicenseUpdateInput struct for LicenseUpdateInput
 type LicenseUpdateInput struct {
-	Description *string  `json:"description,omitempty"`
-	Size        *float32 `json:"size,omitempty"`
+	Description          *string  `json:"description,omitempty"`
+	Size                 *float32 `json:"size,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _LicenseUpdateInput LicenseUpdateInput
 
 // NewLicenseUpdateInput instantiates a new LicenseUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o LicenseUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Size) {
 		toSerialize["size"] = o.Size
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *LicenseUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varLicenseUpdateInput := _LicenseUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varLicenseUpdateInput); err == nil {
+		*o = LicenseUpdateInput(varLicenseUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "size")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableLicenseUpdateInput struct {

--- a/metal/v1/model_membership.go
+++ b/metal/v1/model_membership.go
@@ -21,14 +21,17 @@ var _ MappedNullable = &Membership{}
 
 // Membership struct for Membership
 type Membership struct {
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	Href      *string    `json:"href,omitempty"`
-	Id        *string    `json:"id,omitempty"`
-	Project   *Href      `json:"project,omitempty"`
-	Roles     []string   `json:"roles,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
-	User      *Href      `json:"user,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	Href                 *string    `json:"href,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Project              *Href      `json:"project,omitempty"`
+	Roles                []string   `json:"roles,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	User                 *Href      `json:"user,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Membership Membership
 
 // NewMembership instantiates a new Membership object
 // This constructor will assign default values to properties that have it defined,
@@ -302,7 +305,35 @@ func (o Membership) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.User) {
 		toSerialize["user"] = o.User
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Membership) UnmarshalJSON(bytes []byte) (err error) {
+	varMembership := _Membership{}
+
+	if err = json.Unmarshal(bytes, &varMembership); err == nil {
+		*o = Membership(varMembership)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "roles")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "user")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMembership struct {

--- a/metal/v1/model_membership_input.go
+++ b/metal/v1/model_membership_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MembershipInput{}
 
 // MembershipInput struct for MembershipInput
 type MembershipInput struct {
-	Role []string `json:"role,omitempty"`
+	Role                 []string `json:"role,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MembershipInput MembershipInput
 
 // NewMembershipInput instantiates a new MembershipInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MembershipInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Role) {
 		toSerialize["role"] = o.Role
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MembershipInput) UnmarshalJSON(bytes []byte) (err error) {
+	varMembershipInput := _MembershipInput{}
+
+	if err = json.Unmarshal(bytes, &varMembershipInput); err == nil {
+		*o = MembershipInput(varMembershipInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "role")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMembershipInput struct {

--- a/metal/v1/model_membership_list.go
+++ b/metal/v1/model_membership_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MembershipList{}
 
 // MembershipList struct for MembershipList
 type MembershipList struct {
-	Memberships []Membership `json:"memberships,omitempty"`
+	Memberships          []Membership `json:"memberships,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MembershipList MembershipList
 
 // NewMembershipList instantiates a new MembershipList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MembershipList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Memberships) {
 		toSerialize["memberships"] = o.Memberships
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MembershipList) UnmarshalJSON(bytes []byte) (err error) {
+	varMembershipList := _MembershipList{}
+
+	if err = json.Unmarshal(bytes, &varMembershipList); err == nil {
+		*o = MembershipList(varMembershipList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "memberships")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMembershipList struct {

--- a/metal/v1/model_meta.go
+++ b/metal/v1/model_meta.go
@@ -20,15 +20,18 @@ var _ MappedNullable = &Meta{}
 
 // Meta struct for Meta
 type Meta struct {
-	First       *Href  `json:"first,omitempty"`
-	Last        *Href  `json:"last,omitempty"`
-	Next        *Href  `json:"next,omitempty"`
-	Previous    *Href  `json:"previous,omitempty"`
-	Self        *Href  `json:"self,omitempty"`
-	Total       *int32 `json:"total,omitempty"`
-	CurrentPage *int32 `json:"current_page,omitempty"`
-	LastPage    *int32 `json:"last_page,omitempty"`
+	First                *Href  `json:"first,omitempty"`
+	Last                 *Href  `json:"last,omitempty"`
+	Next                 *Href  `json:"next,omitempty"`
+	Previous             *Href  `json:"previous,omitempty"`
+	Self                 *Href  `json:"self,omitempty"`
+	Total                *int32 `json:"total,omitempty"`
+	CurrentPage          *int32 `json:"current_page,omitempty"`
+	LastPage             *int32 `json:"last_page,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Meta Meta
 
 // NewMeta instantiates a new Meta object
 // This constructor will assign default values to properties that have it defined,
@@ -337,7 +340,36 @@ func (o Meta) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.LastPage) {
 		toSerialize["last_page"] = o.LastPage
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Meta) UnmarshalJSON(bytes []byte) (err error) {
+	varMeta := _Meta{}
+
+	if err = json.Unmarshal(bytes, &varMeta); err == nil {
+		*o = Meta(varMeta)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "first")
+		delete(additionalProperties, "last")
+		delete(additionalProperties, "next")
+		delete(additionalProperties, "previous")
+		delete(additionalProperties, "self")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "current_page")
+		delete(additionalProperties, "last_page")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMeta struct {

--- a/metal/v1/model_metadata.go
+++ b/metal/v1/model_metadata.go
@@ -37,12 +37,15 @@ type Metadata struct {
 	PrivateSubnets []string `json:"private_subnets,omitempty"`
 	Reserved       *bool    `json:"reserved,omitempty"`
 	// The specs of the plan version of the instance
-	Specs         map[string]interface{} `json:"specs,omitempty"`
-	SshKeys       []string               `json:"ssh_keys,omitempty"`
-	SwitchShortId *string                `json:"switch_short_id,omitempty"`
-	Tags          []string               `json:"tags,omitempty"`
-	Volumes       []string               `json:"volumes,omitempty"`
+	Specs                map[string]interface{} `json:"specs,omitempty"`
+	SshKeys              []string               `json:"ssh_keys,omitempty"`
+	SwitchShortId        *string                `json:"switch_short_id,omitempty"`
+	Tags                 []string               `json:"tags,omitempty"`
+	Volumes              []string               `json:"volumes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Metadata Metadata
 
 // NewMetadata instantiates a new Metadata object
 // This constructor will assign default values to properties that have it defined,
@@ -666,7 +669,45 @@ func (o Metadata) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Metadata) UnmarshalJSON(bytes []byte) (err error) {
+	varMetadata := _Metadata{}
+
+	if err = json.Unmarshal(bytes, &varMetadata); err == nil {
+		*o = Metadata(varMetadata)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "iqn")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "network")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "private_subnets")
+		delete(additionalProperties, "reserved")
+		delete(additionalProperties, "specs")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "switch_short_id")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "volumes")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetadata struct {

--- a/metal/v1/model_metadata_network.go
+++ b/metal/v1/model_metadata_network.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &MetadataNetwork{}
 
 // MetadataNetwork struct for MetadataNetwork
 type MetadataNetwork struct {
-	Addresses  []string                 `json:"addresses,omitempty"`
-	Interfaces []map[string]interface{} `json:"interfaces,omitempty"`
-	Network    *MetadataNetworkNetwork  `json:"network,omitempty"`
+	Addresses            []string                 `json:"addresses,omitempty"`
+	Interfaces           []map[string]interface{} `json:"interfaces,omitempty"`
+	Network              *MetadataNetworkNetwork  `json:"network,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetadataNetwork MetadataNetwork
 
 // NewMetadataNetwork instantiates a new MetadataNetwork object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o MetadataNetwork) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Network) {
 		toSerialize["network"] = o.Network
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetadataNetwork) UnmarshalJSON(bytes []byte) (err error) {
+	varMetadataNetwork := _MetadataNetwork{}
+
+	if err = json.Unmarshal(bytes, &varMetadataNetwork); err == nil {
+		*o = MetadataNetwork(varMetadataNetwork)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "addresses")
+		delete(additionalProperties, "interfaces")
+		delete(additionalProperties, "network")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetadataNetwork struct {

--- a/metal/v1/model_metadata_network_network.go
+++ b/metal/v1/model_metadata_network_network.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MetadataNetworkNetwork{}
 
 // MetadataNetworkNetwork struct for MetadataNetworkNetwork
 type MetadataNetworkNetwork struct {
-	Bonding *MetadataNetworkNetworkBonding `json:"bonding,omitempty"`
+	Bonding              *MetadataNetworkNetworkBonding `json:"bonding,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetadataNetworkNetwork MetadataNetworkNetwork
 
 // NewMetadataNetworkNetwork instantiates a new MetadataNetworkNetwork object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MetadataNetworkNetwork) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Bonding) {
 		toSerialize["bonding"] = o.Bonding
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetadataNetworkNetwork) UnmarshalJSON(bytes []byte) (err error) {
+	varMetadataNetworkNetwork := _MetadataNetworkNetwork{}
+
+	if err = json.Unmarshal(bytes, &varMetadataNetworkNetwork); err == nil {
+		*o = MetadataNetworkNetwork(varMetadataNetworkNetwork)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bonding")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetadataNetworkNetwork struct {

--- a/metal/v1/model_metadata_network_network_bonding.go
+++ b/metal/v1/model_metadata_network_network_bonding.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &MetadataNetworkNetworkBonding{}
 
 // MetadataNetworkNetworkBonding struct for MetadataNetworkNetworkBonding
 type MetadataNetworkNetworkBonding struct {
-	LinkAggregation *string `json:"link_aggregation,omitempty"`
-	Mac             *string `json:"mac,omitempty"`
-	Mode            *int32  `json:"mode,omitempty"`
+	LinkAggregation      *string `json:"link_aggregation,omitempty"`
+	Mac                  *string `json:"mac,omitempty"`
+	Mode                 *int32  `json:"mode,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetadataNetworkNetworkBonding MetadataNetworkNetworkBonding
 
 // NewMetadataNetworkNetworkBonding instantiates a new MetadataNetworkNetworkBonding object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o MetadataNetworkNetworkBonding) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Mode) {
 		toSerialize["mode"] = o.Mode
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetadataNetworkNetworkBonding) UnmarshalJSON(bytes []byte) (err error) {
+	varMetadataNetworkNetworkBonding := _MetadataNetworkNetworkBonding{}
+
+	if err = json.Unmarshal(bytes, &varMetadataNetworkNetworkBonding); err == nil {
+		*o = MetadataNetworkNetworkBonding(varMetadataNetworkNetworkBonding)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "link_aggregation")
+		delete(additionalProperties, "mac")
+		delete(additionalProperties, "mode")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetadataNetworkNetworkBonding struct {

--- a/metal/v1/model_metal_gateway.go
+++ b/metal/v1/model_metal_gateway.go
@@ -28,10 +28,13 @@ type MetalGateway struct {
 	IpReservation *IPReservation `json:"ip_reservation,omitempty"`
 	Project       *Project       `json:"project,omitempty"`
 	// The current state of the Metal Gateway. 'Ready' indicates the gateway record has been configured, but is currently not active on the network. 'Active' indicates the gateway has been configured on the network. 'Deleting' is a temporary state used to indicate that the gateway is in the process of being un-configured from the network, after which the gateway record will be deleted.
-	State          *string         `json:"state,omitempty"`
-	UpdatedAt      *time.Time      `json:"updated_at,omitempty"`
-	VirtualNetwork *VirtualNetwork `json:"virtual_network,omitempty"`
+	State                *string         `json:"state,omitempty"`
+	UpdatedAt            *time.Time      `json:"updated_at,omitempty"`
+	VirtualNetwork       *VirtualNetwork `json:"virtual_network,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetalGateway MetalGateway
 
 // NewMetalGateway instantiates a new MetalGateway object
 // This constructor will assign default values to properties that have it defined,
@@ -375,7 +378,37 @@ func (o MetalGateway) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.VirtualNetwork) {
 		toSerialize["virtual_network"] = o.VirtualNetwork
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetalGateway) UnmarshalJSON(bytes []byte) (err error) {
+	varMetalGateway := _MetalGateway{}
+
+	if err = json.Unmarshal(bytes, &varMetalGateway); err == nil {
+		*o = MetalGateway(varMetalGateway)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "created_by")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "ip_reservation")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "virtual_network")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetalGateway struct {

--- a/metal/v1/model_metal_gateway_create_input.go
+++ b/metal/v1/model_metal_gateway_create_input.go
@@ -25,8 +25,11 @@ type MetalGatewayCreateInput struct {
 	// The subnet size (8, 16, 32, 64, or 128) of the private IPv4 reservation that will be created for the metal gateway. This field is required unless a project IP reservation was specified.           Please keep in mind that the number of private metal gateway ranges are limited per project. If you would like to increase the limit per project, please contact support for assistance.
 	PrivateIpv4SubnetSize *int32 `json:"private_ipv4_subnet_size,omitempty"`
 	// The UUID of a metro virtual network that belongs to the same project as where the metal gateway will be created in.
-	VirtualNetworkId string `json:"virtual_network_id"`
+	VirtualNetworkId     string `json:"virtual_network_id"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetalGatewayCreateInput MetalGatewayCreateInput
 
 // NewMetalGatewayCreateInput instantiates a new MetalGatewayCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -151,7 +154,31 @@ func (o MetalGatewayCreateInput) ToMap() (map[string]interface{}, error) {
 		toSerialize["private_ipv4_subnet_size"] = o.PrivateIpv4SubnetSize
 	}
 	toSerialize["virtual_network_id"] = o.VirtualNetworkId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetalGatewayCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varMetalGatewayCreateInput := _MetalGatewayCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varMetalGatewayCreateInput); err == nil {
+		*o = MetalGatewayCreateInput(varMetalGatewayCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ip_reservation_id")
+		delete(additionalProperties, "private_ipv4_subnet_size")
+		delete(additionalProperties, "virtual_network_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetalGatewayCreateInput struct {

--- a/metal/v1/model_metal_gateway_list.go
+++ b/metal/v1/model_metal_gateway_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MetalGatewayList{}
 
 // MetalGatewayList struct for MetalGatewayList
 type MetalGatewayList struct {
-	MetalGateways []MetalGatewayListMetalGatewaysInner `json:"metal_gateways,omitempty"`
+	MetalGateways        []MetalGatewayListMetalGatewaysInner `json:"metal_gateways,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetalGatewayList MetalGatewayList
 
 // NewMetalGatewayList instantiates a new MetalGatewayList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MetalGatewayList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.MetalGateways) {
 		toSerialize["metal_gateways"] = o.MetalGateways
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetalGatewayList) UnmarshalJSON(bytes []byte) (err error) {
+	varMetalGatewayList := _MetalGatewayList{}
+
+	if err = json.Unmarshal(bytes, &varMetalGatewayList); err == nil {
+		*o = MetalGatewayList(varMetalGatewayList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "metal_gateways")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetalGatewayList struct {

--- a/metal/v1/model_metal_gateway_lite.go
+++ b/metal/v1/model_metal_gateway_lite.go
@@ -30,8 +30,11 @@ type MetalGatewayLite struct {
 	State     *string    `json:"state,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	// The VLAN id of the Virtual Network record associated to this Metal Gateway.
-	Vlan *int32 `json:"vlan,omitempty"`
+	Vlan                 *int32 `json:"vlan,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetalGatewayLite MetalGatewayLite
 
 // NewMetalGatewayLite instantiates a new MetalGatewayLite object
 // This constructor will assign default values to properties that have it defined,
@@ -305,7 +308,35 @@ func (o MetalGatewayLite) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vlan) {
 		toSerialize["vlan"] = o.Vlan
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetalGatewayLite) UnmarshalJSON(bytes []byte) (err error) {
+	varMetalGatewayLite := _MetalGatewayLite{}
+
+	if err = json.Unmarshal(bytes, &varMetalGatewayLite); err == nil {
+		*o = MetalGatewayLite(varMetalGatewayLite)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "gateway_address")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "vlan")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetalGatewayLite struct {

--- a/metal/v1/model_metro.go
+++ b/metal/v1/model_metro.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &Metro{}
 
 // Metro struct for Metro
 type Metro struct {
-	Code    *string `json:"code,omitempty"`
-	Country *string `json:"country,omitempty"`
-	Id      *string `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
+	Code                 *string `json:"code,omitempty"`
+	Country              *string `json:"country,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Metro Metro
 
 // NewMetro instantiates a new Metro object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o Metro) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Metro) UnmarshalJSON(bytes []byte) (err error) {
+	varMetro := _Metro{}
+
+	if err = json.Unmarshal(bytes, &varMetro); err == nil {
+		*o = Metro(varMetro)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetro struct {

--- a/metal/v1/model_metro_capacity_list.go
+++ b/metal/v1/model_metro_capacity_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MetroCapacityList{}
 
 // MetroCapacityList struct for MetroCapacityList
 type MetroCapacityList struct {
-	Capacity *MetroCapacityReport `json:"capacity,omitempty"`
+	Capacity             *MetroCapacityReport `json:"capacity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetroCapacityList MetroCapacityList
 
 // NewMetroCapacityList instantiates a new MetroCapacityList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MetroCapacityList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Capacity) {
 		toSerialize["capacity"] = o.Capacity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetroCapacityList) UnmarshalJSON(bytes []byte) (err error) {
+	varMetroCapacityList := _MetroCapacityList{}
+
+	if err = json.Unmarshal(bytes, &varMetroCapacityList); err == nil {
+		*o = MetroCapacityList(varMetroCapacityList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "capacity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetroCapacityList struct {

--- a/metal/v1/model_metro_capacity_report.go
+++ b/metal/v1/model_metro_capacity_report.go
@@ -20,27 +20,30 @@ var _ MappedNullable = &MetroCapacityReport{}
 
 // MetroCapacityReport struct for MetroCapacityReport
 type MetroCapacityReport struct {
-	Am *CapacityPerFacility `json:"am,omitempty"`
-	At *CapacityPerFacility `json:"at,omitempty"`
-	Ch *CapacityPerFacility `json:"ch,omitempty"`
-	Da *CapacityPerFacility `json:"da,omitempty"`
-	Dc *CapacityPerFacility `json:"dc,omitempty"`
-	Fr *CapacityPerFacility `json:"fr,omitempty"`
-	Hk *CapacityPerFacility `json:"hk,omitempty"`
-	La *CapacityPerFacility `json:"la,omitempty"`
-	Ld *CapacityPerFacility `json:"ld,omitempty"`
-	Md *CapacityPerFacility `json:"md,omitempty"`
-	Ny *CapacityPerFacility `json:"ny,omitempty"`
-	Pa *CapacityPerFacility `json:"pa,omitempty"`
-	Se *CapacityPerFacility `json:"se,omitempty"`
-	Sg *CapacityPerFacility `json:"sg,omitempty"`
-	Sl *CapacityPerFacility `json:"sl,omitempty"`
-	Sp *CapacityPerFacility `json:"sp,omitempty"`
-	Sv *CapacityPerFacility `json:"sv,omitempty"`
-	Sy *CapacityPerFacility `json:"sy,omitempty"`
-	Tr *CapacityPerFacility `json:"tr,omitempty"`
-	Ty *CapacityPerFacility `json:"ty,omitempty"`
+	Am                   *CapacityPerFacility `json:"am,omitempty"`
+	At                   *CapacityPerFacility `json:"at,omitempty"`
+	Ch                   *CapacityPerFacility `json:"ch,omitempty"`
+	Da                   *CapacityPerFacility `json:"da,omitempty"`
+	Dc                   *CapacityPerFacility `json:"dc,omitempty"`
+	Fr                   *CapacityPerFacility `json:"fr,omitempty"`
+	Hk                   *CapacityPerFacility `json:"hk,omitempty"`
+	La                   *CapacityPerFacility `json:"la,omitempty"`
+	Ld                   *CapacityPerFacility `json:"ld,omitempty"`
+	Md                   *CapacityPerFacility `json:"md,omitempty"`
+	Ny                   *CapacityPerFacility `json:"ny,omitempty"`
+	Pa                   *CapacityPerFacility `json:"pa,omitempty"`
+	Se                   *CapacityPerFacility `json:"se,omitempty"`
+	Sg                   *CapacityPerFacility `json:"sg,omitempty"`
+	Sl                   *CapacityPerFacility `json:"sl,omitempty"`
+	Sp                   *CapacityPerFacility `json:"sp,omitempty"`
+	Sv                   *CapacityPerFacility `json:"sv,omitempty"`
+	Sy                   *CapacityPerFacility `json:"sy,omitempty"`
+	Tr                   *CapacityPerFacility `json:"tr,omitempty"`
+	Ty                   *CapacityPerFacility `json:"ty,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetroCapacityReport MetroCapacityReport
 
 // NewMetroCapacityReport instantiates a new MetroCapacityReport object
 // This constructor will assign default values to properties that have it defined,
@@ -769,7 +772,48 @@ func (o MetroCapacityReport) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Ty) {
 		toSerialize["ty"] = o.Ty
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetroCapacityReport) UnmarshalJSON(bytes []byte) (err error) {
+	varMetroCapacityReport := _MetroCapacityReport{}
+
+	if err = json.Unmarshal(bytes, &varMetroCapacityReport); err == nil {
+		*o = MetroCapacityReport(varMetroCapacityReport)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "am")
+		delete(additionalProperties, "at")
+		delete(additionalProperties, "ch")
+		delete(additionalProperties, "da")
+		delete(additionalProperties, "dc")
+		delete(additionalProperties, "fr")
+		delete(additionalProperties, "hk")
+		delete(additionalProperties, "la")
+		delete(additionalProperties, "ld")
+		delete(additionalProperties, "md")
+		delete(additionalProperties, "ny")
+		delete(additionalProperties, "pa")
+		delete(additionalProperties, "se")
+		delete(additionalProperties, "sg")
+		delete(additionalProperties, "sl")
+		delete(additionalProperties, "sp")
+		delete(additionalProperties, "sv")
+		delete(additionalProperties, "sy")
+		delete(additionalProperties, "tr")
+		delete(additionalProperties, "ty")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetroCapacityReport struct {

--- a/metal/v1/model_metro_input.go
+++ b/metal/v1/model_metro_input.go
@@ -21,8 +21,11 @@ var _ MappedNullable = &MetroInput{}
 // MetroInput struct for MetroInput
 type MetroInput struct {
 	// Metro code or ID of where the instance should be provisioned in. Either metro or facility must be provided.
-	Metro string `json:"metro"`
+	Metro                string `json:"metro"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetroInput MetroInput
 
 // NewMetroInput instantiates a new MetroInput object
 // This constructor will assign default values to properties that have it defined,
@@ -77,7 +80,29 @@ func (o MetroInput) MarshalJSON() ([]byte, error) {
 func (o MetroInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["metro"] = o.Metro
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetroInput) UnmarshalJSON(bytes []byte) (err error) {
+	varMetroInput := _MetroInput{}
+
+	if err = json.Unmarshal(bytes, &varMetroInput); err == nil {
+		*o = MetroInput(varMetroInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "metro")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetroInput struct {

--- a/metal/v1/model_metro_list.go
+++ b/metal/v1/model_metro_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MetroList{}
 
 // MetroList struct for MetroList
 type MetroList struct {
-	Metros []Metro `json:"metros,omitempty"`
+	Metros               []Metro `json:"metros,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetroList MetroList
 
 // NewMetroList instantiates a new MetroList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MetroList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Metros) {
 		toSerialize["metros"] = o.Metros
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetroList) UnmarshalJSON(bytes []byte) (err error) {
+	varMetroList := _MetroList{}
+
+	if err = json.Unmarshal(bytes, &varMetroList); err == nil {
+		*o = MetroList(varMetroList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "metros")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetroList struct {

--- a/metal/v1/model_metro_server_info.go
+++ b/metal/v1/model_metro_server_info.go
@@ -25,8 +25,11 @@ type MetroServerInfo struct {
 	// The plan ID or slug to check the capacity of.
 	Plan *string `json:"plan,omitempty"`
 	// The number of servers to check the capacity of.
-	Quantity *string `json:"quantity,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MetroServerInfo MetroServerInfo
 
 // NewMetroServerInfo instantiates a new MetroServerInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -160,7 +163,31 @@ func (o MetroServerInfo) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MetroServerInfo) UnmarshalJSON(bytes []byte) (err error) {
+	varMetroServerInfo := _MetroServerInfo{}
+
+	if err = json.Unmarshal(bytes, &varMetroServerInfo); err == nil {
+		*o = MetroServerInfo(varMetroServerInfo)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "quantity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMetroServerInfo struct {

--- a/metal/v1/model_mount.go
+++ b/metal/v1/model_mount.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &Mount{}
 
 // Mount struct for Mount
 type Mount struct {
-	Device  *string  `json:"device,omitempty"`
-	Format  *string  `json:"format,omitempty"`
-	Point   *string  `json:"point,omitempty"`
-	Options []string `json:"options,omitempty"`
+	Device               *string  `json:"device,omitempty"`
+	Format               *string  `json:"format,omitempty"`
+	Point                *string  `json:"point,omitempty"`
+	Options              []string `json:"options,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Mount Mount
 
 // NewMount instantiates a new Mount object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o Mount) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Options) {
 		toSerialize["options"] = o.Options
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Mount) UnmarshalJSON(bytes []byte) (err error) {
+	varMount := _Mount{}
+
+	if err = json.Unmarshal(bytes, &varMount); err == nil {
+		*o = Mount(varMount)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "device")
+		delete(additionalProperties, "format")
+		delete(additionalProperties, "point")
+		delete(additionalProperties, "options")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMount struct {

--- a/metal/v1/model_move_hardware_reservation_request.go
+++ b/metal/v1/model_move_hardware_reservation_request.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &MoveHardwareReservationRequest{}
 
 // MoveHardwareReservationRequest struct for MoveHardwareReservationRequest
 type MoveHardwareReservationRequest struct {
-	ProjectId *string `json:"project_id,omitempty"`
+	ProjectId            *string `json:"project_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MoveHardwareReservationRequest MoveHardwareReservationRequest
 
 // NewMoveHardwareReservationRequest instantiates a new MoveHardwareReservationRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o MoveHardwareReservationRequest) ToMap() (map[string]interface{}, error) 
 	if !isNil(o.ProjectId) {
 		toSerialize["project_id"] = o.ProjectId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MoveHardwareReservationRequest) UnmarshalJSON(bytes []byte) (err error) {
+	varMoveHardwareReservationRequest := _MoveHardwareReservationRequest{}
+
+	if err = json.Unmarshal(bytes, &varMoveHardwareReservationRequest); err == nil {
+		*o = MoveHardwareReservationRequest(varMoveHardwareReservationRequest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "project_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMoveHardwareReservationRequest struct {

--- a/metal/v1/model_new_password.go
+++ b/metal/v1/model_new_password.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &NewPassword{}
 
 // NewPassword struct for NewPassword
 type NewPassword struct {
-	NewPassword *string `json:"new_password,omitempty"`
+	NewPassword          *string `json:"new_password,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _NewPassword NewPassword
 
 // NewNewPassword instantiates a new NewPassword object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o NewPassword) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.NewPassword) {
 		toSerialize["new_password"] = o.NewPassword
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *NewPassword) UnmarshalJSON(bytes []byte) (err error) {
+	varNewPassword := _NewPassword{}
+
+	if err = json.Unmarshal(bytes, &varNewPassword); err == nil {
+		*o = NewPassword(varNewPassword)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "new_password")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableNewPassword struct {

--- a/metal/v1/model_operating_system.go
+++ b/metal/v1/model_operating_system.go
@@ -29,11 +29,14 @@ type OperatingSystem struct {
 	// Servers can be already preinstalled with OS in order to shorten provision time.
 	Preinstallable *bool `json:"preinstallable,omitempty"`
 	// This object contains price per time unit and optional multiplier value if licence price depends on hardware plan or components (e.g. number of cores)
-	Pricing         map[string]interface{} `json:"pricing,omitempty"`
-	ProvisionableOn []string               `json:"provisionable_on,omitempty"`
-	Slug            *string                `json:"slug,omitempty"`
-	Version         *string                `json:"version,omitempty"`
+	Pricing              map[string]interface{} `json:"pricing,omitempty"`
+	ProvisionableOn      []string               `json:"provisionable_on,omitempty"`
+	Slug                 *string                `json:"slug,omitempty"`
+	Version              *string                `json:"version,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _OperatingSystem OperatingSystem
 
 // NewOperatingSystem instantiates a new OperatingSystem object
 // This constructor will assign default values to properties that have it defined,
@@ -412,7 +415,38 @@ func (o OperatingSystem) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Version) {
 		toSerialize["version"] = o.Version
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *OperatingSystem) UnmarshalJSON(bytes []byte) (err error) {
+	varOperatingSystem := _OperatingSystem{}
+
+	if err = json.Unmarshal(bytes, &varOperatingSystem); err == nil {
+		*o = OperatingSystem(varOperatingSystem)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "distro")
+		delete(additionalProperties, "distro_label")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "licensed")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "preinstallable")
+		delete(additionalProperties, "pricing")
+		delete(additionalProperties, "provisionable_on")
+		delete(additionalProperties, "slug")
+		delete(additionalProperties, "version")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOperatingSystem struct {

--- a/metal/v1/model_operating_system_list.go
+++ b/metal/v1/model_operating_system_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &OperatingSystemList{}
 
 // OperatingSystemList struct for OperatingSystemList
 type OperatingSystemList struct {
-	OperatingSystems []OperatingSystem `json:"operating_systems,omitempty"`
+	OperatingSystems     []OperatingSystem `json:"operating_systems,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _OperatingSystemList OperatingSystemList
 
 // NewOperatingSystemList instantiates a new OperatingSystemList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o OperatingSystemList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.OperatingSystems) {
 		toSerialize["operating_systems"] = o.OperatingSystems
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *OperatingSystemList) UnmarshalJSON(bytes []byte) (err error) {
+	varOperatingSystemList := _OperatingSystemList{}
+
+	if err = json.Unmarshal(bytes, &varOperatingSystemList); err == nil {
+		*o = OperatingSystemList(varOperatingSystemList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "operating_systems")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOperatingSystemList struct {

--- a/metal/v1/model_organization.go
+++ b/metal/v1/model_organization.go
@@ -29,18 +29,21 @@ type Organization struct {
 	Customdata     map[string]interface{} `json:"customdata,omitempty"`
 	Description    *string                `json:"description,omitempty"`
 	// Force to all members to have enabled the two factor authentication after that date, unless the value is null
-	Enforce2faAt *time.Time `json:"enforce_2fa_at,omitempty"`
-	Id           *string    `json:"id,omitempty"`
-	Logo         **os.File  `json:"logo,omitempty"`
-	Members      []Href     `json:"members,omitempty"`
-	Memberships  []Href     `json:"memberships,omitempty"`
-	Name         *string    `json:"name,omitempty"`
-	Projects     []Href     `json:"projects,omitempty"`
-	Terms        *int32     `json:"terms,omitempty"`
-	Twitter      *string    `json:"twitter,omitempty"`
-	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
-	Website      *string    `json:"website,omitempty"`
+	Enforce2faAt         *time.Time `json:"enforce_2fa_at,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Logo                 **os.File  `json:"logo,omitempty"`
+	Members              []Href     `json:"members,omitempty"`
+	Memberships          []Href     `json:"memberships,omitempty"`
+	Name                 *string    `json:"name,omitempty"`
+	Projects             []Href     `json:"projects,omitempty"`
+	Terms                *int32     `json:"terms,omitempty"`
+	Twitter              *string    `json:"twitter,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	Website              *string    `json:"website,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Organization Organization
 
 // NewOrganization instantiates a new Organization object
 // This constructor will assign default values to properties that have it defined,
@@ -664,7 +667,45 @@ func (o Organization) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Website) {
 		toSerialize["website"] = o.Website
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Organization) UnmarshalJSON(bytes []byte) (err error) {
+	varOrganization := _Organization{}
+
+	if err = json.Unmarshal(bytes, &varOrganization); err == nil {
+		*o = Organization(varOrganization)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "billing_address")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "credit_amount")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "enforce_2fa_at")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "logo")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "memberships")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "projects")
+		delete(additionalProperties, "terms")
+		delete(additionalProperties, "twitter")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "website")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOrganization struct {

--- a/metal/v1/model_organization_input.go
+++ b/metal/v1/model_organization_input.go
@@ -27,12 +27,15 @@ type OrganizationInput struct {
 	Customdata     map[string]interface{} `json:"customdata,omitempty"`
 	Description    *string                `json:"description,omitempty"`
 	// Force to all members to have enabled the two factor authentication after that date, unless the value is null
-	Enforce2faAt *time.Time `json:"enforce_2fa_at,omitempty"`
-	Logo         **os.File  `json:"logo,omitempty"`
-	Name         *string    `json:"name,omitempty"`
-	Twitter      *string    `json:"twitter,omitempty"`
-	Website      *string    `json:"website,omitempty"`
+	Enforce2faAt         *time.Time `json:"enforce_2fa_at,omitempty"`
+	Logo                 **os.File  `json:"logo,omitempty"`
+	Name                 *string    `json:"name,omitempty"`
+	Twitter              *string    `json:"twitter,omitempty"`
+	Website              *string    `json:"website,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _OrganizationInput OrganizationInput
 
 // NewOrganizationInput instantiates a new OrganizationInput object
 // This constructor will assign default values to properties that have it defined,
@@ -376,7 +379,37 @@ func (o OrganizationInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Website) {
 		toSerialize["website"] = o.Website
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *OrganizationInput) UnmarshalJSON(bytes []byte) (err error) {
+	varOrganizationInput := _OrganizationInput{}
+
+	if err = json.Unmarshal(bytes, &varOrganizationInput); err == nil {
+		*o = OrganizationInput(varOrganizationInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "billing_address")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "enforce_2fa_at")
+		delete(additionalProperties, "logo")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "twitter")
+		delete(additionalProperties, "website")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOrganizationInput struct {

--- a/metal/v1/model_organization_list.go
+++ b/metal/v1/model_organization_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &OrganizationList{}
 
 // OrganizationList struct for OrganizationList
 type OrganizationList struct {
-	Meta          *Meta          `json:"meta,omitempty"`
-	Organizations []Organization `json:"organizations,omitempty"`
+	Meta                 *Meta          `json:"meta,omitempty"`
+	Organizations        []Organization `json:"organizations,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _OrganizationList OrganizationList
 
 // NewOrganizationList instantiates a new OrganizationList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o OrganizationList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Organizations) {
 		toSerialize["organizations"] = o.Organizations
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *OrganizationList) UnmarshalJSON(bytes []byte) (err error) {
+	varOrganizationList := _OrganizationList{}
+
+	if err = json.Unmarshal(bytes, &varOrganizationList); err == nil {
+		*o = OrganizationList(varOrganizationList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "meta")
+		delete(additionalProperties, "organizations")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOrganizationList struct {

--- a/metal/v1/model_parent_block.go
+++ b/metal/v1/model_parent_block.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &ParentBlock{}
 
 // ParentBlock struct for ParentBlock
 type ParentBlock struct {
-	Cidr    *int32  `json:"cidr,omitempty"`
-	Href    *string `json:"href,omitempty"`
-	Netmask *string `json:"netmask,omitempty"`
-	Network *string `json:"network,omitempty"`
+	Cidr                 *int32  `json:"cidr,omitempty"`
+	Href                 *string `json:"href,omitempty"`
+	Netmask              *string `json:"netmask,omitempty"`
+	Network              *string `json:"network,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ParentBlock ParentBlock
 
 // NewParentBlock instantiates a new ParentBlock object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o ParentBlock) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Network) {
 		toSerialize["network"] = o.Network
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ParentBlock) UnmarshalJSON(bytes []byte) (err error) {
+	varParentBlock := _ParentBlock{}
+
+	if err = json.Unmarshal(bytes, &varParentBlock); err == nil {
+		*o = ParentBlock(varParentBlock)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "cidr")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "netmask")
+		delete(additionalProperties, "network")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableParentBlock struct {

--- a/metal/v1/model_partition.go
+++ b/metal/v1/model_partition.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &Partition{}
 
 // Partition struct for Partition
 type Partition struct {
-	Label  *string `json:"label,omitempty"`
-	Number *int32  `json:"number,omitempty"`
-	Size   *string `json:"size,omitempty"`
+	Label                *string `json:"label,omitempty"`
+	Number               *int32  `json:"number,omitempty"`
+	Size                 *string `json:"size,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Partition Partition
 
 // NewPartition instantiates a new Partition object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o Partition) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Size) {
 		toSerialize["size"] = o.Size
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Partition) UnmarshalJSON(bytes []byte) (err error) {
+	varPartition := _Partition{}
+
+	if err = json.Unmarshal(bytes, &varPartition); err == nil {
+		*o = Partition(varPartition)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "number")
+		delete(additionalProperties, "size")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePartition struct {

--- a/metal/v1/model_payment_method.go
+++ b/metal/v1/model_payment_method.go
@@ -21,22 +21,25 @@ var _ MappedNullable = &PaymentMethod{}
 
 // PaymentMethod struct for PaymentMethod
 type PaymentMethod struct {
-	BillingAddress  *PaymentMethodBillingAddress `json:"billing_address,omitempty"`
-	CardType        *string                      `json:"card_type,omitempty"`
-	CardholderName  *string                      `json:"cardholder_name,omitempty"`
-	CreatedAt       *time.Time                   `json:"created_at,omitempty"`
-	CreatedByUser   *Href                        `json:"created_by_user,omitempty"`
-	Default         *bool                        `json:"default,omitempty"`
-	Email           *string                      `json:"email,omitempty"`
-	ExpirationMonth *string                      `json:"expiration_month,omitempty"`
-	ExpirationYear  *string                      `json:"expiration_year,omitempty"`
-	Id              *string                      `json:"id,omitempty"`
-	Name            *string                      `json:"name,omitempty"`
-	Organization    *Href                        `json:"organization,omitempty"`
-	Projects        []Href                       `json:"projects,omitempty"`
-	Type            *string                      `json:"type,omitempty"`
-	UpdatedAt       *time.Time                   `json:"updated_at,omitempty"`
+	BillingAddress       *PaymentMethodBillingAddress `json:"billing_address,omitempty"`
+	CardType             *string                      `json:"card_type,omitempty"`
+	CardholderName       *string                      `json:"cardholder_name,omitempty"`
+	CreatedAt            *time.Time                   `json:"created_at,omitempty"`
+	CreatedByUser        *Href                        `json:"created_by_user,omitempty"`
+	Default              *bool                        `json:"default,omitempty"`
+	Email                *string                      `json:"email,omitempty"`
+	ExpirationMonth      *string                      `json:"expiration_month,omitempty"`
+	ExpirationYear       *string                      `json:"expiration_year,omitempty"`
+	Id                   *string                      `json:"id,omitempty"`
+	Name                 *string                      `json:"name,omitempty"`
+	Organization         *Href                        `json:"organization,omitempty"`
+	Projects             []Href                       `json:"projects,omitempty"`
+	Type                 *string                      `json:"type,omitempty"`
+	UpdatedAt            *time.Time                   `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PaymentMethod PaymentMethod
 
 // NewPaymentMethod instantiates a new PaymentMethod object
 // This constructor will assign default values to properties that have it defined,
@@ -590,7 +593,43 @@ func (o PaymentMethod) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PaymentMethod) UnmarshalJSON(bytes []byte) (err error) {
+	varPaymentMethod := _PaymentMethod{}
+
+	if err = json.Unmarshal(bytes, &varPaymentMethod); err == nil {
+		*o = PaymentMethod(varPaymentMethod)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "billing_address")
+		delete(additionalProperties, "card_type")
+		delete(additionalProperties, "cardholder_name")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "created_by_user")
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "expiration_month")
+		delete(additionalProperties, "expiration_year")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "organization")
+		delete(additionalProperties, "projects")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePaymentMethod struct {

--- a/metal/v1/model_payment_method_billing_address.go
+++ b/metal/v1/model_payment_method_billing_address.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &PaymentMethodBillingAddress{}
 
 // PaymentMethodBillingAddress struct for PaymentMethodBillingAddress
 type PaymentMethodBillingAddress struct {
-	CountryCodeAlpha2 *string `json:"country_code_alpha2,omitempty"`
-	PostalCode        *string `json:"postal_code,omitempty"`
-	StreetAddress     *string `json:"street_address,omitempty"`
+	CountryCodeAlpha2    *string `json:"country_code_alpha2,omitempty"`
+	PostalCode           *string `json:"postal_code,omitempty"`
+	StreetAddress        *string `json:"street_address,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PaymentMethodBillingAddress PaymentMethodBillingAddress
 
 // NewPaymentMethodBillingAddress instantiates a new PaymentMethodBillingAddress object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o PaymentMethodBillingAddress) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.StreetAddress) {
 		toSerialize["street_address"] = o.StreetAddress
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PaymentMethodBillingAddress) UnmarshalJSON(bytes []byte) (err error) {
+	varPaymentMethodBillingAddress := _PaymentMethodBillingAddress{}
+
+	if err = json.Unmarshal(bytes, &varPaymentMethodBillingAddress); err == nil {
+		*o = PaymentMethodBillingAddress(varPaymentMethodBillingAddress)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "country_code_alpha2")
+		delete(additionalProperties, "postal_code")
+		delete(additionalProperties, "street_address")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePaymentMethodBillingAddress struct {

--- a/metal/v1/model_payment_method_create_input.go
+++ b/metal/v1/model_payment_method_create_input.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &PaymentMethodCreateInput{}
 
 // PaymentMethodCreateInput struct for PaymentMethodCreateInput
 type PaymentMethodCreateInput struct {
-	Default *bool  `json:"default,omitempty"`
-	Name    string `json:"name"`
-	Nonce   string `json:"nonce"`
+	Default              *bool  `json:"default,omitempty"`
+	Name                 string `json:"name"`
+	Nonce                string `json:"nonce"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PaymentMethodCreateInput PaymentMethodCreateInput
 
 // NewPaymentMethodCreateInput instantiates a new PaymentMethodCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -139,7 +142,31 @@ func (o PaymentMethodCreateInput) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["name"] = o.Name
 	toSerialize["nonce"] = o.Nonce
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PaymentMethodCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varPaymentMethodCreateInput := _PaymentMethodCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varPaymentMethodCreateInput); err == nil {
+		*o = PaymentMethodCreateInput(varPaymentMethodCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "nonce")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePaymentMethodCreateInput struct {

--- a/metal/v1/model_payment_method_list.go
+++ b/metal/v1/model_payment_method_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PaymentMethodList{}
 
 // PaymentMethodList struct for PaymentMethodList
 type PaymentMethodList struct {
-	PaymentMethods []PaymentMethod `json:"payment_methods,omitempty"`
+	PaymentMethods       []PaymentMethod `json:"payment_methods,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PaymentMethodList PaymentMethodList
 
 // NewPaymentMethodList instantiates a new PaymentMethodList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PaymentMethodList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.PaymentMethods) {
 		toSerialize["payment_methods"] = o.PaymentMethods
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PaymentMethodList) UnmarshalJSON(bytes []byte) (err error) {
+	varPaymentMethodList := _PaymentMethodList{}
+
+	if err = json.Unmarshal(bytes, &varPaymentMethodList); err == nil {
+		*o = PaymentMethodList(varPaymentMethodList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "payment_methods")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePaymentMethodList struct {

--- a/metal/v1/model_payment_method_update_input.go
+++ b/metal/v1/model_payment_method_update_input.go
@@ -20,13 +20,16 @@ var _ MappedNullable = &PaymentMethodUpdateInput{}
 
 // PaymentMethodUpdateInput struct for PaymentMethodUpdateInput
 type PaymentMethodUpdateInput struct {
-	BillingAddress  map[string]interface{} `json:"billing_address,omitempty"`
-	CardholderName  *string                `json:"cardholder_name,omitempty"`
-	Default         *bool                  `json:"default,omitempty"`
-	ExpirationMonth *string                `json:"expiration_month,omitempty"`
-	ExpirationYear  *int32                 `json:"expiration_year,omitempty"`
-	Name            *string                `json:"name,omitempty"`
+	BillingAddress       map[string]interface{} `json:"billing_address,omitempty"`
+	CardholderName       *string                `json:"cardholder_name,omitempty"`
+	Default              *bool                  `json:"default,omitempty"`
+	ExpirationMonth      *string                `json:"expiration_month,omitempty"`
+	ExpirationYear       *int32                 `json:"expiration_year,omitempty"`
+	Name                 *string                `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PaymentMethodUpdateInput PaymentMethodUpdateInput
 
 // NewPaymentMethodUpdateInput instantiates a new PaymentMethodUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -265,7 +268,34 @@ func (o PaymentMethodUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PaymentMethodUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varPaymentMethodUpdateInput := _PaymentMethodUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varPaymentMethodUpdateInput); err == nil {
+		*o = PaymentMethodUpdateInput(varPaymentMethodUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "billing_address")
+		delete(additionalProperties, "cardholder_name")
+		delete(additionalProperties, "default")
+		delete(additionalProperties, "expiration_month")
+		delete(additionalProperties, "expiration_year")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePaymentMethodUpdateInput struct {

--- a/metal/v1/model_plan.go
+++ b/metal/v1/model_plan.go
@@ -35,8 +35,11 @@ type Plan struct {
 	Slug              *string                      `json:"slug,omitempty"`
 	Specs             *PlanSpecs                   `json:"specs,omitempty"`
 	// The plan type
-	Type *string `json:"type,omitempty"`
+	Type                 *string `json:"type,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Plan Plan
 
 // NewPlan instantiates a new Plan object
 // This constructor will assign default values to properties that have it defined,
@@ -520,7 +523,41 @@ func (o Plan) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Plan) UnmarshalJSON(bytes []byte) (err error) {
+	varPlan := _Plan{}
+
+	if err = json.Unmarshal(bytes, &varPlan); err == nil {
+		*o = Plan(varPlan)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "available_in")
+		delete(additionalProperties, "available_in_metros")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "deployment_types")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "legacy")
+		delete(additionalProperties, "line")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "pricing")
+		delete(additionalProperties, "slug")
+		delete(additionalProperties, "specs")
+		delete(additionalProperties, "type")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlan struct {

--- a/metal/v1/model_plan_available_in_inner.go
+++ b/metal/v1/model_plan_available_in_inner.go
@@ -21,9 +21,12 @@ var _ MappedNullable = &PlanAvailableInInner{}
 // PlanAvailableInInner struct for PlanAvailableInInner
 type PlanAvailableInInner struct {
 	// href to the Facility
-	Href  *string                    `json:"href,omitempty"`
-	Price *PlanAvailableInInnerPrice `json:"price,omitempty"`
+	Href                 *string                    `json:"href,omitempty"`
+	Price                *PlanAvailableInInnerPrice `json:"price,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanAvailableInInner PlanAvailableInInner
 
 // NewPlanAvailableInInner instantiates a new PlanAvailableInInner object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,30 @@ func (o PlanAvailableInInner) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Price) {
 		toSerialize["price"] = o.Price
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanAvailableInInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanAvailableInInner := _PlanAvailableInInner{}
+
+	if err = json.Unmarshal(bytes, &varPlanAvailableInInner); err == nil {
+		*o = PlanAvailableInInner(varPlanAvailableInInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "price")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanAvailableInInner struct {

--- a/metal/v1/model_plan_available_in_inner_price.go
+++ b/metal/v1/model_plan_available_in_inner_price.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PlanAvailableInInnerPrice{}
 
 // PlanAvailableInInnerPrice struct for PlanAvailableInInnerPrice
 type PlanAvailableInInnerPrice struct {
-	Hour *float32 `json:"hour,omitempty"`
+	Hour                 *float32 `json:"hour,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanAvailableInInnerPrice PlanAvailableInInnerPrice
 
 // NewPlanAvailableInInnerPrice instantiates a new PlanAvailableInInnerPrice object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PlanAvailableInInnerPrice) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Hour) {
 		toSerialize["hour"] = o.Hour
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanAvailableInInnerPrice) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanAvailableInInnerPrice := _PlanAvailableInInnerPrice{}
+
+	if err = json.Unmarshal(bytes, &varPlanAvailableInInnerPrice); err == nil {
+		*o = PlanAvailableInInnerPrice(varPlanAvailableInInnerPrice)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "hour")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanAvailableInInnerPrice struct {

--- a/metal/v1/model_plan_available_in_metros_inner.go
+++ b/metal/v1/model_plan_available_in_metros_inner.go
@@ -21,9 +21,12 @@ var _ MappedNullable = &PlanAvailableInMetrosInner{}
 // PlanAvailableInMetrosInner struct for PlanAvailableInMetrosInner
 type PlanAvailableInMetrosInner struct {
 	// href to the Metro
-	Href  *string                    `json:"href,omitempty"`
-	Price *PlanAvailableInInnerPrice `json:"price,omitempty"`
+	Href                 *string                    `json:"href,omitempty"`
+	Price                *PlanAvailableInInnerPrice `json:"price,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanAvailableInMetrosInner PlanAvailableInMetrosInner
 
 // NewPlanAvailableInMetrosInner instantiates a new PlanAvailableInMetrosInner object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,30 @@ func (o PlanAvailableInMetrosInner) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Price) {
 		toSerialize["price"] = o.Price
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanAvailableInMetrosInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanAvailableInMetrosInner := _PlanAvailableInMetrosInner{}
+
+	if err = json.Unmarshal(bytes, &varPlanAvailableInMetrosInner); err == nil {
+		*o = PlanAvailableInMetrosInner(varPlanAvailableInMetrosInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "price")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanAvailableInMetrosInner struct {

--- a/metal/v1/model_plan_list.go
+++ b/metal/v1/model_plan_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PlanList{}
 
 // PlanList struct for PlanList
 type PlanList struct {
-	Plans []Plan `json:"plans,omitempty"`
+	Plans                []Plan `json:"plans,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanList PlanList
 
 // NewPlanList instantiates a new PlanList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PlanList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Plans) {
 		toSerialize["plans"] = o.Plans
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanList) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanList := _PlanList{}
+
+	if err = json.Unmarshal(bytes, &varPlanList); err == nil {
+		*o = PlanList(varPlanList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "plans")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanList struct {

--- a/metal/v1/model_plan_specs.go
+++ b/metal/v1/model_plan_specs.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &PlanSpecs{}
 
 // PlanSpecs struct for PlanSpecs
 type PlanSpecs struct {
-	Cpus     []PlanSpecsCpusInner   `json:"cpus,omitempty"`
-	Drives   []PlanSpecsDrivesInner `json:"drives,omitempty"`
-	Nics     []PlanSpecsNicsInner   `json:"nics,omitempty"`
-	Features *PlanSpecsFeatures     `json:"features,omitempty"`
+	Cpus                 []PlanSpecsCpusInner   `json:"cpus,omitempty"`
+	Drives               []PlanSpecsDrivesInner `json:"drives,omitempty"`
+	Nics                 []PlanSpecsNicsInner   `json:"nics,omitempty"`
+	Features             *PlanSpecsFeatures     `json:"features,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanSpecs PlanSpecs
 
 // NewPlanSpecs instantiates a new PlanSpecs object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o PlanSpecs) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Features) {
 		toSerialize["features"] = o.Features
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanSpecs) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanSpecs := _PlanSpecs{}
+
+	if err = json.Unmarshal(bytes, &varPlanSpecs); err == nil {
+		*o = PlanSpecs(varPlanSpecs)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "cpus")
+		delete(additionalProperties, "drives")
+		delete(additionalProperties, "nics")
+		delete(additionalProperties, "features")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanSpecs struct {

--- a/metal/v1/model_plan_specs_cpus_inner.go
+++ b/metal/v1/model_plan_specs_cpus_inner.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &PlanSpecsCpusInner{}
 
 // PlanSpecsCpusInner struct for PlanSpecsCpusInner
 type PlanSpecsCpusInner struct {
-	Count *int32  `json:"count,omitempty"`
-	Type  *string `json:"type,omitempty"`
+	Count                *int32  `json:"count,omitempty"`
+	Type                 *string `json:"type,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanSpecsCpusInner PlanSpecsCpusInner
 
 // NewPlanSpecsCpusInner instantiates a new PlanSpecsCpusInner object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o PlanSpecsCpusInner) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanSpecsCpusInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanSpecsCpusInner := _PlanSpecsCpusInner{}
+
+	if err = json.Unmarshal(bytes, &varPlanSpecsCpusInner); err == nil {
+		*o = PlanSpecsCpusInner(varPlanSpecsCpusInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "count")
+		delete(additionalProperties, "type")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanSpecsCpusInner struct {

--- a/metal/v1/model_plan_specs_drives_inner.go
+++ b/metal/v1/model_plan_specs_drives_inner.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &PlanSpecsDrivesInner{}
 
 // PlanSpecsDrivesInner struct for PlanSpecsDrivesInner
 type PlanSpecsDrivesInner struct {
-	Count    *int32  `json:"count,omitempty"`
-	Type     *string `json:"type,omitempty"`
-	Size     *string `json:"size,omitempty"`
-	Category *string `json:"category,omitempty"`
+	Count                *int32  `json:"count,omitempty"`
+	Type                 *string `json:"type,omitempty"`
+	Size                 *string `json:"size,omitempty"`
+	Category             *string `json:"category,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanSpecsDrivesInner PlanSpecsDrivesInner
 
 // NewPlanSpecsDrivesInner instantiates a new PlanSpecsDrivesInner object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o PlanSpecsDrivesInner) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Category) {
 		toSerialize["category"] = o.Category
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanSpecsDrivesInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanSpecsDrivesInner := _PlanSpecsDrivesInner{}
+
+	if err = json.Unmarshal(bytes, &varPlanSpecsDrivesInner); err == nil {
+		*o = PlanSpecsDrivesInner(varPlanSpecsDrivesInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "count")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "size")
+		delete(additionalProperties, "category")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanSpecsDrivesInner struct {

--- a/metal/v1/model_plan_specs_features.go
+++ b/metal/v1/model_plan_specs_features.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &PlanSpecsFeatures{}
 
 // PlanSpecsFeatures struct for PlanSpecsFeatures
 type PlanSpecsFeatures struct {
-	Raid *bool `json:"raid,omitempty"`
-	Txt  *bool `json:"txt,omitempty"`
-	Uefi *bool `json:"uefi,omitempty"`
+	Raid                 *bool `json:"raid,omitempty"`
+	Txt                  *bool `json:"txt,omitempty"`
+	Uefi                 *bool `json:"uefi,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanSpecsFeatures PlanSpecsFeatures
 
 // NewPlanSpecsFeatures instantiates a new PlanSpecsFeatures object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o PlanSpecsFeatures) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Uefi) {
 		toSerialize["uefi"] = o.Uefi
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanSpecsFeatures) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanSpecsFeatures := _PlanSpecsFeatures{}
+
+	if err = json.Unmarshal(bytes, &varPlanSpecsFeatures); err == nil {
+		*o = PlanSpecsFeatures(varPlanSpecsFeatures)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "raid")
+		delete(additionalProperties, "txt")
+		delete(additionalProperties, "uefi")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanSpecsFeatures struct {

--- a/metal/v1/model_plan_specs_nics_inner.go
+++ b/metal/v1/model_plan_specs_nics_inner.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &PlanSpecsNicsInner{}
 
 // PlanSpecsNicsInner struct for PlanSpecsNicsInner
 type PlanSpecsNicsInner struct {
-	Count *int32  `json:"count,omitempty"`
-	Type  *string `json:"type,omitempty"`
+	Count                *int32  `json:"count,omitempty"`
+	Type                 *string `json:"type,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PlanSpecsNicsInner PlanSpecsNicsInner
 
 // NewPlanSpecsNicsInner instantiates a new PlanSpecsNicsInner object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o PlanSpecsNicsInner) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PlanSpecsNicsInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPlanSpecsNicsInner := _PlanSpecsNicsInner{}
+
+	if err = json.Unmarshal(bytes, &varPlanSpecsNicsInner); err == nil {
+		*o = PlanSpecsNicsInner(varPlanSpecsNicsInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "count")
+		delete(additionalProperties, "type")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePlanSpecsNicsInner struct {

--- a/metal/v1/model_port.go
+++ b/metal/v1/model_port.go
@@ -33,7 +33,10 @@ type Port struct {
 	NetworkType          *string         `json:"network_type,omitempty"`
 	NativeVirtualNetwork *VirtualNetwork `json:"native_virtual_network,omitempty"`
 	VirtualNetworks      []Href          `json:"virtual_networks,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Port Port
 
 // NewPort instantiates a new Port object
 // This constructor will assign default values to properties that have it defined,
@@ -412,7 +415,38 @@ func (o Port) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.VirtualNetworks) {
 		toSerialize["virtual_networks"] = o.VirtualNetworks
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Port) UnmarshalJSON(bytes []byte) (err error) {
+	varPort := _Port{}
+
+	if err = json.Unmarshal(bytes, &varPort); err == nil {
+		*o = Port(varPort)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bond")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "disbond_operation_supported")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "network_type")
+		delete(additionalProperties, "native_virtual_network")
+		delete(additionalProperties, "virtual_networks")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePort struct {

--- a/metal/v1/model_port_assign_input.go
+++ b/metal/v1/model_port_assign_input.go
@@ -21,8 +21,11 @@ var _ MappedNullable = &PortAssignInput{}
 // PortAssignInput struct for PortAssignInput
 type PortAssignInput struct {
 	// Virtual Network ID. May be the UUID of the Virtual Network record, or the VLAN value itself.
-	Vnid *string `json:"vnid,omitempty"`
+	Vnid                 *string `json:"vnid,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortAssignInput PortAssignInput
 
 // NewPortAssignInput instantiates a new PortAssignInput object
 // This constructor will assign default values to properties that have it defined,
@@ -86,7 +89,29 @@ func (o PortAssignInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vnid) {
 		toSerialize["vnid"] = o.Vnid
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortAssignInput) UnmarshalJSON(bytes []byte) (err error) {
+	varPortAssignInput := _PortAssignInput{}
+
+	if err = json.Unmarshal(bytes, &varPortAssignInput); err == nil {
+		*o = PortAssignInput(varPortAssignInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "vnid")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortAssignInput struct {

--- a/metal/v1/model_port_convert_layer3_input.go
+++ b/metal/v1/model_port_convert_layer3_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PortConvertLayer3Input{}
 
 // PortConvertLayer3Input struct for PortConvertLayer3Input
 type PortConvertLayer3Input struct {
-	RequestIps []PortConvertLayer3InputRequestIpsInner `json:"request_ips,omitempty"`
+	RequestIps           []PortConvertLayer3InputRequestIpsInner `json:"request_ips,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortConvertLayer3Input PortConvertLayer3Input
 
 // NewPortConvertLayer3Input instantiates a new PortConvertLayer3Input object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PortConvertLayer3Input) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.RequestIps) {
 		toSerialize["request_ips"] = o.RequestIps
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortConvertLayer3Input) UnmarshalJSON(bytes []byte) (err error) {
+	varPortConvertLayer3Input := _PortConvertLayer3Input{}
+
+	if err = json.Unmarshal(bytes, &varPortConvertLayer3Input); err == nil {
+		*o = PortConvertLayer3Input(varPortConvertLayer3Input)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "request_ips")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortConvertLayer3Input struct {

--- a/metal/v1/model_port_convert_layer3_input_request_ips_inner.go
+++ b/metal/v1/model_port_convert_layer3_input_request_ips_inner.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &PortConvertLayer3InputRequestIpsInner{}
 
 // PortConvertLayer3InputRequestIpsInner struct for PortConvertLayer3InputRequestIpsInner
 type PortConvertLayer3InputRequestIpsInner struct {
-	AddressFamily *int32 `json:"address_family,omitempty"`
-	Public        *bool  `json:"public,omitempty"`
+	AddressFamily        *int32 `json:"address_family,omitempty"`
+	Public               *bool  `json:"public,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortConvertLayer3InputRequestIpsInner PortConvertLayer3InputRequestIpsInner
 
 // NewPortConvertLayer3InputRequestIpsInner instantiates a new PortConvertLayer3InputRequestIpsInner object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o PortConvertLayer3InputRequestIpsInner) ToMap() (map[string]interface{}, 
 	if !isNil(o.Public) {
 		toSerialize["public"] = o.Public
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortConvertLayer3InputRequestIpsInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPortConvertLayer3InputRequestIpsInner := _PortConvertLayer3InputRequestIpsInner{}
+
+	if err = json.Unmarshal(bytes, &varPortConvertLayer3InputRequestIpsInner); err == nil {
+		*o = PortConvertLayer3InputRequestIpsInner(varPortConvertLayer3InputRequestIpsInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "public")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortConvertLayer3InputRequestIpsInner struct {

--- a/metal/v1/model_port_data.go
+++ b/metal/v1/model_port_data.go
@@ -23,8 +23,11 @@ type PortData struct {
 	// MAC address is set for NetworkPort ports
 	Mac *string `json:"mac,omitempty"`
 	// Bonded is true for NetworkPort ports in a bond and NetworkBondPort ports that are active
-	Bonded *bool `json:"bonded,omitempty"`
+	Bonded               *bool `json:"bonded,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortData PortData
 
 // NewPortData instantiates a new PortData object
 // This constructor will assign default values to properties that have it defined,
@@ -123,7 +126,30 @@ func (o PortData) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Bonded) {
 		toSerialize["bonded"] = o.Bonded
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortData) UnmarshalJSON(bytes []byte) (err error) {
+	varPortData := _PortData{}
+
+	if err = json.Unmarshal(bytes, &varPortData); err == nil {
+		*o = PortData(varPortData)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "mac")
+		delete(additionalProperties, "bonded")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortData struct {

--- a/metal/v1/model_port_vlan_assignment.go
+++ b/metal/v1/model_port_vlan_assignment.go
@@ -21,15 +21,18 @@ var _ MappedNullable = &PortVlanAssignment{}
 
 // PortVlanAssignment struct for PortVlanAssignment
 type PortVlanAssignment struct {
-	CreatedAt      *time.Time `json:"created_at,omitempty"`
-	Id             *string    `json:"id,omitempty"`
-	Native         *bool      `json:"native,omitempty"`
-	Port           *Href      `json:"port,omitempty"`
-	State          *string    `json:"state,omitempty"`
-	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
-	VirtualNetwork *Href      `json:"virtual_network,omitempty"`
-	Vlan           *int32     `json:"vlan,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Native               *bool      `json:"native,omitempty"`
+	Port                 *Href      `json:"port,omitempty"`
+	State                *string    `json:"state,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	VirtualNetwork       *Href      `json:"virtual_network,omitempty"`
+	Vlan                 *int32     `json:"vlan,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignment PortVlanAssignment
 
 // NewPortVlanAssignment instantiates a new PortVlanAssignment object
 // This constructor will assign default values to properties that have it defined,
@@ -338,7 +341,36 @@ func (o PortVlanAssignment) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vlan) {
 		toSerialize["vlan"] = o.Vlan
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignment) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignment := _PortVlanAssignment{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignment); err == nil {
+		*o = PortVlanAssignment(varPortVlanAssignment)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "native")
+		delete(additionalProperties, "port")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "virtual_network")
+		delete(additionalProperties, "vlan")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignment struct {

--- a/metal/v1/model_port_vlan_assignment_batch.go
+++ b/metal/v1/model_port_vlan_assignment_batch.go
@@ -21,16 +21,19 @@ var _ MappedNullable = &PortVlanAssignmentBatch{}
 
 // PortVlanAssignmentBatch struct for PortVlanAssignmentBatch
 type PortVlanAssignmentBatch struct {
-	CreatedAt       *time.Time                                    `json:"created_at,omitempty"`
-	ErrorMessages   []string                                      `json:"error_messages,omitempty"`
-	Id              *string                                       `json:"id,omitempty"`
-	Port            *Port                                         `json:"port,omitempty"`
-	Quantity        *int32                                        `json:"quantity,omitempty"`
-	State           *string                                       `json:"state,omitempty"`
-	UpdatedAt       *time.Time                                    `json:"updated_at,omitempty"`
-	VlanAssignments []PortVlanAssignmentBatchVlanAssignmentsInner `json:"vlan_assignments,omitempty"`
-	Project         *Href                                         `json:"project,omitempty"`
+	CreatedAt            *time.Time                                    `json:"created_at,omitempty"`
+	ErrorMessages        []string                                      `json:"error_messages,omitempty"`
+	Id                   *string                                       `json:"id,omitempty"`
+	Port                 *Port                                         `json:"port,omitempty"`
+	Quantity             *int32                                        `json:"quantity,omitempty"`
+	State                *string                                       `json:"state,omitempty"`
+	UpdatedAt            *time.Time                                    `json:"updated_at,omitempty"`
+	VlanAssignments      []PortVlanAssignmentBatchVlanAssignmentsInner `json:"vlan_assignments,omitempty"`
+	Project              *Href                                         `json:"project,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignmentBatch PortVlanAssignmentBatch
 
 // NewPortVlanAssignmentBatch instantiates a new PortVlanAssignmentBatch object
 // This constructor will assign default values to properties that have it defined,
@@ -374,7 +377,37 @@ func (o PortVlanAssignmentBatch) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Project) {
 		toSerialize["project"] = o.Project
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignmentBatch) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignmentBatch := _PortVlanAssignmentBatch{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatch); err == nil {
+		*o = PortVlanAssignmentBatch(varPortVlanAssignmentBatch)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "error_messages")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "port")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "vlan_assignments")
+		delete(additionalProperties, "project")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignmentBatch struct {

--- a/metal/v1/model_port_vlan_assignment_batch_create_input.go
+++ b/metal/v1/model_port_vlan_assignment_batch_create_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PortVlanAssignmentBatchCreateInput{}
 
 // PortVlanAssignmentBatchCreateInput struct for PortVlanAssignmentBatchCreateInput
 type PortVlanAssignmentBatchCreateInput struct {
-	VlanAssignments []PortVlanAssignmentBatchCreateInputVlanAssignmentsInner `json:"vlan_assignments,omitempty"`
+	VlanAssignments      []PortVlanAssignmentBatchCreateInputVlanAssignmentsInner `json:"vlan_assignments,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignmentBatchCreateInput PortVlanAssignmentBatchCreateInput
 
 // NewPortVlanAssignmentBatchCreateInput instantiates a new PortVlanAssignmentBatchCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PortVlanAssignmentBatchCreateInput) ToMap() (map[string]interface{}, err
 	if !isNil(o.VlanAssignments) {
 		toSerialize["vlan_assignments"] = o.VlanAssignments
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignmentBatchCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignmentBatchCreateInput := _PortVlanAssignmentBatchCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchCreateInput); err == nil {
+		*o = PortVlanAssignmentBatchCreateInput(varPortVlanAssignmentBatchCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "vlan_assignments")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignmentBatchCreateInput struct {

--- a/metal/v1/model_port_vlan_assignment_batch_create_input_vlan_assignments_inner.go
+++ b/metal/v1/model_port_vlan_assignment_batch_create_input_vlan_assignments_inner.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &PortVlanAssignmentBatchCreateInputVlanAssignmentsInner{}
 
 // PortVlanAssignmentBatchCreateInputVlanAssignmentsInner struct for PortVlanAssignmentBatchCreateInputVlanAssignmentsInner
 type PortVlanAssignmentBatchCreateInputVlanAssignmentsInner struct {
-	Native *bool   `json:"native,omitempty"`
-	State  *string `json:"state,omitempty"`
-	Vlan   *string `json:"vlan,omitempty"`
+	Native               *bool   `json:"native,omitempty"`
+	State                *string `json:"state,omitempty"`
+	Vlan                 *string `json:"vlan,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignmentBatchCreateInputVlanAssignmentsInner PortVlanAssignmentBatchCreateInputVlanAssignmentsInner
 
 // NewPortVlanAssignmentBatchCreateInputVlanAssignmentsInner instantiates a new PortVlanAssignmentBatchCreateInputVlanAssignmentsInner object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o PortVlanAssignmentBatchCreateInputVlanAssignmentsInner) ToMap() (map[str
 	if !isNil(o.Vlan) {
 		toSerialize["vlan"] = o.Vlan
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignmentBatchCreateInputVlanAssignmentsInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner := _PortVlanAssignmentBatchCreateInputVlanAssignmentsInner{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner); err == nil {
+		*o = PortVlanAssignmentBatchCreateInputVlanAssignmentsInner(varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "native")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "vlan")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignmentBatchCreateInputVlanAssignmentsInner struct {

--- a/metal/v1/model_port_vlan_assignment_batch_list.go
+++ b/metal/v1/model_port_vlan_assignment_batch_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PortVlanAssignmentBatchList{}
 
 // PortVlanAssignmentBatchList struct for PortVlanAssignmentBatchList
 type PortVlanAssignmentBatchList struct {
-	Batches []PortVlanAssignmentBatch `json:"batches,omitempty"`
+	Batches              []PortVlanAssignmentBatch `json:"batches,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignmentBatchList PortVlanAssignmentBatchList
 
 // NewPortVlanAssignmentBatchList instantiates a new PortVlanAssignmentBatchList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PortVlanAssignmentBatchList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Batches) {
 		toSerialize["batches"] = o.Batches
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignmentBatchList) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignmentBatchList := _PortVlanAssignmentBatchList{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchList); err == nil {
+		*o = PortVlanAssignmentBatchList(varPortVlanAssignmentBatchList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "batches")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignmentBatchList struct {

--- a/metal/v1/model_port_vlan_assignment_batch_vlan_assignments_inner.go
+++ b/metal/v1/model_port_vlan_assignment_batch_vlan_assignments_inner.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &PortVlanAssignmentBatchVlanAssignmentsInner{}
 
 // PortVlanAssignmentBatchVlanAssignmentsInner struct for PortVlanAssignmentBatchVlanAssignmentsInner
 type PortVlanAssignmentBatchVlanAssignmentsInner struct {
-	Id     *string `json:"id,omitempty"`
-	Native *bool   `json:"native,omitempty"`
-	State  *string `json:"state,omitempty"`
-	Vlan   *int32  `json:"vlan,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Native               *bool   `json:"native,omitempty"`
+	State                *string `json:"state,omitempty"`
+	Vlan                 *int32  `json:"vlan,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignmentBatchVlanAssignmentsInner PortVlanAssignmentBatchVlanAssignmentsInner
 
 // NewPortVlanAssignmentBatchVlanAssignmentsInner instantiates a new PortVlanAssignmentBatchVlanAssignmentsInner object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o PortVlanAssignmentBatchVlanAssignmentsInner) ToMap() (map[string]interfa
 	if !isNil(o.Vlan) {
 		toSerialize["vlan"] = o.Vlan
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignmentBatchVlanAssignmentsInner) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignmentBatchVlanAssignmentsInner := _PortVlanAssignmentBatchVlanAssignmentsInner{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchVlanAssignmentsInner); err == nil {
+		*o = PortVlanAssignmentBatchVlanAssignmentsInner(varPortVlanAssignmentBatchVlanAssignmentsInner)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "native")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "vlan")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignmentBatchVlanAssignmentsInner struct {

--- a/metal/v1/model_port_vlan_assignment_list.go
+++ b/metal/v1/model_port_vlan_assignment_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &PortVlanAssignmentList{}
 
 // PortVlanAssignmentList struct for PortVlanAssignmentList
 type PortVlanAssignmentList struct {
-	VlanAssignments []PortVlanAssignment `json:"vlan_assignments,omitempty"`
+	VlanAssignments      []PortVlanAssignment `json:"vlan_assignments,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortVlanAssignmentList PortVlanAssignmentList
 
 // NewPortVlanAssignmentList instantiates a new PortVlanAssignmentList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o PortVlanAssignmentList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.VlanAssignments) {
 		toSerialize["vlan_assignments"] = o.VlanAssignments
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortVlanAssignmentList) UnmarshalJSON(bytes []byte) (err error) {
+	varPortVlanAssignmentList := _PortVlanAssignmentList{}
+
+	if err = json.Unmarshal(bytes, &varPortVlanAssignmentList); err == nil {
+		*o = PortVlanAssignmentList(varPortVlanAssignmentList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "vlan_assignments")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortVlanAssignmentList struct {

--- a/metal/v1/model_project.go
+++ b/metal/v1/model_project.go
@@ -21,23 +21,26 @@ var _ MappedNullable = &Project{}
 
 // Project struct for Project
 type Project struct {
-	BgpConfig     *Href                  `json:"bgp_config,omitempty"`
-	CreatedAt     *time.Time             `json:"created_at,omitempty"`
-	Customdata    map[string]interface{} `json:"customdata,omitempty"`
-	Devices       []Href                 `json:"devices,omitempty"`
-	Href          *string                `json:"href,omitempty"`
-	Id            *string                `json:"id,omitempty"`
-	Invitations   []Href                 `json:"invitations,omitempty"`
-	MaxDevices    map[string]interface{} `json:"max_devices,omitempty"`
-	Members       []Href                 `json:"members,omitempty"`
-	Memberships   []Href                 `json:"memberships,omitempty"`
-	Name          *string                `json:"name,omitempty"`
-	NetworkStatus map[string]interface{} `json:"network_status,omitempty"`
-	PaymentMethod *Href                  `json:"payment_method,omitempty"`
-	SshKeys       []Href                 `json:"ssh_keys,omitempty"`
-	UpdatedAt     *time.Time             `json:"updated_at,omitempty"`
-	Volumes       []Href                 `json:"volumes,omitempty"`
+	BgpConfig            *Href                  `json:"bgp_config,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Devices              []Href                 `json:"devices,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   *string                `json:"id,omitempty"`
+	Invitations          []Href                 `json:"invitations,omitempty"`
+	MaxDevices           map[string]interface{} `json:"max_devices,omitempty"`
+	Members              []Href                 `json:"members,omitempty"`
+	Memberships          []Href                 `json:"memberships,omitempty"`
+	Name                 *string                `json:"name,omitempty"`
+	NetworkStatus        map[string]interface{} `json:"network_status,omitempty"`
+	PaymentMethod        *Href                  `json:"payment_method,omitempty"`
+	SshKeys              []Href                 `json:"ssh_keys,omitempty"`
+	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
+	Volumes              []Href                 `json:"volumes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Project Project
 
 // NewProject instantiates a new Project object
 // This constructor will assign default values to properties that have it defined,
@@ -626,7 +629,44 @@ func (o Project) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Volumes) {
 		toSerialize["volumes"] = o.Volumes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Project) UnmarshalJSON(bytes []byte) (err error) {
+	varProject := _Project{}
+
+	if err = json.Unmarshal(bytes, &varProject); err == nil {
+		*o = Project(varProject)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_config")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "devices")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "invitations")
+		delete(additionalProperties, "max_devices")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "memberships")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "network_status")
+		delete(additionalProperties, "payment_method")
+		delete(additionalProperties, "ssh_keys")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "volumes")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProject struct {

--- a/metal/v1/model_project_create_from_root_input.go
+++ b/metal/v1/model_project_create_from_root_input.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &ProjectCreateFromRootInput{}
 
 // ProjectCreateFromRootInput struct for ProjectCreateFromRootInput
 type ProjectCreateFromRootInput struct {
-	Customdata      map[string]interface{} `json:"customdata,omitempty"`
-	Name            string                 `json:"name"`
-	OrganizationId  *string                `json:"organization_id,omitempty"`
-	PaymentMethodId *string                `json:"payment_method_id,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Name                 string                 `json:"name"`
+	OrganizationId       *string                `json:"organization_id,omitempty"`
+	PaymentMethodId      *string                `json:"payment_method_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProjectCreateFromRootInput ProjectCreateFromRootInput
 
 // NewProjectCreateFromRootInput instantiates a new ProjectCreateFromRootInput object
 // This constructor will assign default values to properties that have it defined,
@@ -184,7 +187,32 @@ func (o ProjectCreateFromRootInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.PaymentMethodId) {
 		toSerialize["payment_method_id"] = o.PaymentMethodId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectCreateFromRootInput) UnmarshalJSON(bytes []byte) (err error) {
+	varProjectCreateFromRootInput := _ProjectCreateFromRootInput{}
+
+	if err = json.Unmarshal(bytes, &varProjectCreateFromRootInput); err == nil {
+		*o = ProjectCreateFromRootInput(varProjectCreateFromRootInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "organization_id")
+		delete(additionalProperties, "payment_method_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectCreateFromRootInput struct {

--- a/metal/v1/model_project_create_input.go
+++ b/metal/v1/model_project_create_input.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &ProjectCreateInput{}
 
 // ProjectCreateInput struct for ProjectCreateInput
 type ProjectCreateInput struct {
-	Customdata      map[string]interface{} `json:"customdata,omitempty"`
-	Name            string                 `json:"name"`
-	PaymentMethodId *string                `json:"payment_method_id,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Name                 string                 `json:"name"`
+	PaymentMethodId      *string                `json:"payment_method_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProjectCreateInput ProjectCreateInput
 
 // NewProjectCreateInput instantiates a new ProjectCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -148,7 +151,31 @@ func (o ProjectCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.PaymentMethodId) {
 		toSerialize["payment_method_id"] = o.PaymentMethodId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varProjectCreateInput := _ProjectCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varProjectCreateInput); err == nil {
+		*o = ProjectCreateInput(varProjectCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "payment_method_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectCreateInput struct {

--- a/metal/v1/model_project_list.go
+++ b/metal/v1/model_project_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &ProjectList{}
 
 // ProjectList struct for ProjectList
 type ProjectList struct {
-	Meta     *Meta     `json:"meta,omitempty"`
-	Projects []Project `json:"projects,omitempty"`
+	Meta                 *Meta     `json:"meta,omitempty"`
+	Projects             []Project `json:"projects,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProjectList ProjectList
 
 // NewProjectList instantiates a new ProjectList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o ProjectList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Projects) {
 		toSerialize["projects"] = o.Projects
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectList) UnmarshalJSON(bytes []byte) (err error) {
+	varProjectList := _ProjectList{}
+
+	if err = json.Unmarshal(bytes, &varProjectList); err == nil {
+		*o = ProjectList(varProjectList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "meta")
+		delete(additionalProperties, "projects")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectList struct {

--- a/metal/v1/model_project_update_input.go
+++ b/metal/v1/model_project_update_input.go
@@ -24,7 +24,10 @@ type ProjectUpdateInput struct {
 	Customdata             map[string]interface{} `json:"customdata,omitempty"`
 	Name                   *string                `json:"name,omitempty"`
 	PaymentMethodId        *string                `json:"payment_method_id,omitempty"`
+	AdditionalProperties   map[string]interface{}
 }
+
+type _ProjectUpdateInput ProjectUpdateInput
 
 // NewProjectUpdateInput instantiates a new ProjectUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o ProjectUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.PaymentMethodId) {
 		toSerialize["payment_method_id"] = o.PaymentMethodId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varProjectUpdateInput := _ProjectUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varProjectUpdateInput); err == nil {
+		*o = ProjectUpdateInput(varProjectUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "backend_transfer_enabled")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "payment_method_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectUpdateInput struct {

--- a/metal/v1/model_project_usage.go
+++ b/metal/v1/model_project_usage.go
@@ -20,16 +20,19 @@ var _ MappedNullable = &ProjectUsage{}
 
 // ProjectUsage struct for ProjectUsage
 type ProjectUsage struct {
-	Facility    *string `json:"facility,omitempty"`
-	Name        *string `json:"name,omitempty"`
-	Plan        *string `json:"plan,omitempty"`
-	PlanVersion *string `json:"plan_version,omitempty"`
-	Price       *string `json:"price,omitempty"`
-	Quantity    *string `json:"quantity,omitempty"`
-	Total       *string `json:"total,omitempty"`
-	Type        *string `json:"type,omitempty"`
-	Unit        *string `json:"unit,omitempty"`
+	Facility             *string `json:"facility,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	Plan                 *string `json:"plan,omitempty"`
+	PlanVersion          *string `json:"plan_version,omitempty"`
+	Price                *string `json:"price,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
+	Total                *string `json:"total,omitempty"`
+	Type                 *string `json:"type,omitempty"`
+	Unit                 *string `json:"unit,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProjectUsage ProjectUsage
 
 // NewProjectUsage instantiates a new ProjectUsage object
 // This constructor will assign default values to properties that have it defined,
@@ -373,7 +376,37 @@ func (o ProjectUsage) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Unit) {
 		toSerialize["unit"] = o.Unit
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectUsage) UnmarshalJSON(bytes []byte) (err error) {
+	varProjectUsage := _ProjectUsage{}
+
+	if err = json.Unmarshal(bytes, &varProjectUsage); err == nil {
+		*o = ProjectUsage(varProjectUsage)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "plan_version")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "unit")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectUsage struct {

--- a/metal/v1/model_project_usage_list.go
+++ b/metal/v1/model_project_usage_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &ProjectUsageList{}
 
 // ProjectUsageList struct for ProjectUsageList
 type ProjectUsageList struct {
-	Usages []ProjectUsage `json:"usages,omitempty"`
+	Usages               []ProjectUsage `json:"usages,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProjectUsageList ProjectUsageList
 
 // NewProjectUsageList instantiates a new ProjectUsageList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o ProjectUsageList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Usages) {
 		toSerialize["usages"] = o.Usages
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectUsageList) UnmarshalJSON(bytes []byte) (err error) {
+	varProjectUsageList := _ProjectUsageList{}
+
+	if err = json.Unmarshal(bytes, &varProjectUsageList); err == nil {
+		*o = ProjectUsageList(varProjectUsageList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "usages")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectUsageList struct {

--- a/metal/v1/model_raid.go
+++ b/metal/v1/model_raid.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &Raid{}
 
 // Raid struct for Raid
 type Raid struct {
-	Devices []string `json:"devices,omitempty"`
-	Level   *string  `json:"level,omitempty"`
-	Name    *string  `json:"name,omitempty"`
+	Devices              []string `json:"devices,omitempty"`
+	Level                *string  `json:"level,omitempty"`
+	Name                 *string  `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Raid Raid
 
 // NewRaid instantiates a new Raid object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o Raid) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Raid) UnmarshalJSON(bytes []byte) (err error) {
+	varRaid := _Raid{}
+
+	if err = json.Unmarshal(bytes, &varRaid); err == nil {
+		*o = Raid(varRaid)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "devices")
+		delete(additionalProperties, "level")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableRaid struct {

--- a/metal/v1/model_recovery_code_list.go
+++ b/metal/v1/model_recovery_code_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &RecoveryCodeList{}
 
 // RecoveryCodeList struct for RecoveryCodeList
 type RecoveryCodeList struct {
-	RecoveryCodes []string `json:"recovery_codes,omitempty"`
+	RecoveryCodes        []string `json:"recovery_codes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _RecoveryCodeList RecoveryCodeList
 
 // NewRecoveryCodeList instantiates a new RecoveryCodeList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o RecoveryCodeList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.RecoveryCodes) {
 		toSerialize["recovery_codes"] = o.RecoveryCodes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *RecoveryCodeList) UnmarshalJSON(bytes []byte) (err error) {
+	varRecoveryCodeList := _RecoveryCodeList{}
+
+	if err = json.Unmarshal(bytes, &varRecoveryCodeList); err == nil {
+		*o = RecoveryCodeList(varRecoveryCodeList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "recovery_codes")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableRecoveryCodeList struct {

--- a/metal/v1/model_self_service_reservation_item_request.go
+++ b/metal/v1/model_self_service_reservation_item_request.go
@@ -20,12 +20,15 @@ var _ MappedNullable = &SelfServiceReservationItemRequest{}
 
 // SelfServiceReservationItemRequest struct for SelfServiceReservationItemRequest
 type SelfServiceReservationItemRequest struct {
-	Amount   *float32 `json:"amount,omitempty"`
-	MetroId  *string  `json:"metro_id,omitempty"`
-	PlanId   *string  `json:"plan_id,omitempty"`
-	Quantity *int32   `json:"quantity,omitempty"`
-	Term     *string  `json:"term,omitempty"`
+	Amount               *float32 `json:"amount,omitempty"`
+	MetroId              *string  `json:"metro_id,omitempty"`
+	PlanId               *string  `json:"plan_id,omitempty"`
+	Quantity             *int32   `json:"quantity,omitempty"`
+	Term                 *string  `json:"term,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SelfServiceReservationItemRequest SelfServiceReservationItemRequest
 
 // NewSelfServiceReservationItemRequest instantiates a new SelfServiceReservationItemRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -229,7 +232,33 @@ func (o SelfServiceReservationItemRequest) ToMap() (map[string]interface{}, erro
 	if !isNil(o.Term) {
 		toSerialize["term"] = o.Term
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SelfServiceReservationItemRequest) UnmarshalJSON(bytes []byte) (err error) {
+	varSelfServiceReservationItemRequest := _SelfServiceReservationItemRequest{}
+
+	if err = json.Unmarshal(bytes, &varSelfServiceReservationItemRequest); err == nil {
+		*o = SelfServiceReservationItemRequest(varSelfServiceReservationItemRequest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "metro_id")
+		delete(additionalProperties, "plan_id")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "term")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSelfServiceReservationItemRequest struct {

--- a/metal/v1/model_self_service_reservation_item_response.go
+++ b/metal/v1/model_self_service_reservation_item_response.go
@@ -20,17 +20,20 @@ var _ MappedNullable = &SelfServiceReservationItemResponse{}
 
 // SelfServiceReservationItemResponse struct for SelfServiceReservationItemResponse
 type SelfServiceReservationItemResponse struct {
-	Amount    *float32 `json:"amount,omitempty"`
-	Id        *string  `json:"id,omitempty"`
-	MetroCode *string  `json:"metro_code,omitempty"`
-	MetroId   *string  `json:"metro_id,omitempty"`
-	MetroName *string  `json:"metro_name,omitempty"`
-	PlanId    *string  `json:"plan_id,omitempty"`
-	PlanName  *string  `json:"plan_name,omitempty"`
-	PlanSlug  *string  `json:"plan_slug,omitempty"`
-	Quantity  *int32   `json:"quantity,omitempty"`
-	Term      *string  `json:"term,omitempty"`
+	Amount               *float32 `json:"amount,omitempty"`
+	Id                   *string  `json:"id,omitempty"`
+	MetroCode            *string  `json:"metro_code,omitempty"`
+	MetroId              *string  `json:"metro_id,omitempty"`
+	MetroName            *string  `json:"metro_name,omitempty"`
+	PlanId               *string  `json:"plan_id,omitempty"`
+	PlanName             *string  `json:"plan_name,omitempty"`
+	PlanSlug             *string  `json:"plan_slug,omitempty"`
+	Quantity             *int32   `json:"quantity,omitempty"`
+	Term                 *string  `json:"term,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SelfServiceReservationItemResponse SelfServiceReservationItemResponse
 
 // NewSelfServiceReservationItemResponse instantiates a new SelfServiceReservationItemResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -409,7 +412,38 @@ func (o SelfServiceReservationItemResponse) ToMap() (map[string]interface{}, err
 	if !isNil(o.Term) {
 		toSerialize["term"] = o.Term
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SelfServiceReservationItemResponse) UnmarshalJSON(bytes []byte) (err error) {
+	varSelfServiceReservationItemResponse := _SelfServiceReservationItemResponse{}
+
+	if err = json.Unmarshal(bytes, &varSelfServiceReservationItemResponse); err == nil {
+		*o = SelfServiceReservationItemResponse(varSelfServiceReservationItemResponse)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "metro_code")
+		delete(additionalProperties, "metro_id")
+		delete(additionalProperties, "metro_name")
+		delete(additionalProperties, "plan_id")
+		delete(additionalProperties, "plan_name")
+		delete(additionalProperties, "plan_slug")
+		delete(additionalProperties, "quantity")
+		delete(additionalProperties, "term")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSelfServiceReservationItemResponse struct {

--- a/metal/v1/model_self_service_reservation_list.go
+++ b/metal/v1/model_self_service_reservation_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SelfServiceReservationList{}
 
 // SelfServiceReservationList struct for SelfServiceReservationList
 type SelfServiceReservationList struct {
-	Reservations []SelfServiceReservationResponse `json:"reservations,omitempty"`
+	Reservations         []SelfServiceReservationResponse `json:"reservations,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SelfServiceReservationList SelfServiceReservationList
 
 // NewSelfServiceReservationList instantiates a new SelfServiceReservationList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SelfServiceReservationList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Reservations) {
 		toSerialize["reservations"] = o.Reservations
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SelfServiceReservationList) UnmarshalJSON(bytes []byte) (err error) {
+	varSelfServiceReservationList := _SelfServiceReservationList{}
+
+	if err = json.Unmarshal(bytes, &varSelfServiceReservationList); err == nil {
+		*o = SelfServiceReservationList(varSelfServiceReservationList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "reservations")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSelfServiceReservationList struct {

--- a/metal/v1/model_self_service_reservation_response.go
+++ b/metal/v1/model_self_service_reservation_response.go
@@ -21,18 +21,21 @@ var _ MappedNullable = &SelfServiceReservationResponse{}
 
 // SelfServiceReservationResponse struct for SelfServiceReservationResponse
 type SelfServiceReservationResponse struct {
-	CreatedAt      *time.Time                                 `json:"created_at,omitempty"`
-	Item           []SelfServiceReservationItemResponse       `json:"item,omitempty"`
-	Notes          *string                                    `json:"notes,omitempty"`
-	Organization   *string                                    `json:"organization,omitempty"`
-	OrganizationId *string                                    `json:"organization_id,omitempty"`
-	Period         *CreateSelfServiceReservationRequestPeriod `json:"period,omitempty"`
-	Project        *string                                    `json:"project,omitempty"`
-	ProjectId      *string                                    `json:"project_id,omitempty"`
-	StartDate      *time.Time                                 `json:"start_date,omitempty"`
-	Status         *string                                    `json:"status,omitempty"`
-	TotalCost      *int32                                     `json:"total_cost,omitempty"`
+	CreatedAt            *time.Time                                 `json:"created_at,omitempty"`
+	Item                 []SelfServiceReservationItemResponse       `json:"item,omitempty"`
+	Notes                *string                                    `json:"notes,omitempty"`
+	Organization         *string                                    `json:"organization,omitempty"`
+	OrganizationId       *string                                    `json:"organization_id,omitempty"`
+	Period               *CreateSelfServiceReservationRequestPeriod `json:"period,omitempty"`
+	Project              *string                                    `json:"project,omitempty"`
+	ProjectId            *string                                    `json:"project_id,omitempty"`
+	StartDate            *time.Time                                 `json:"start_date,omitempty"`
+	Status               *string                                    `json:"status,omitempty"`
+	TotalCost            *int32                                     `json:"total_cost,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SelfServiceReservationResponse SelfServiceReservationResponse
 
 // NewSelfServiceReservationResponse instantiates a new SelfServiceReservationResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -446,7 +449,39 @@ func (o SelfServiceReservationResponse) ToMap() (map[string]interface{}, error) 
 	if !isNil(o.TotalCost) {
 		toSerialize["total_cost"] = o.TotalCost
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SelfServiceReservationResponse) UnmarshalJSON(bytes []byte) (err error) {
+	varSelfServiceReservationResponse := _SelfServiceReservationResponse{}
+
+	if err = json.Unmarshal(bytes, &varSelfServiceReservationResponse); err == nil {
+		*o = SelfServiceReservationResponse(varSelfServiceReservationResponse)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "item")
+		delete(additionalProperties, "notes")
+		delete(additionalProperties, "organization")
+		delete(additionalProperties, "organization_id")
+		delete(additionalProperties, "period")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "project_id")
+		delete(additionalProperties, "start_date")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "total_cost")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSelfServiceReservationResponse struct {

--- a/metal/v1/model_server_info.go
+++ b/metal/v1/model_server_info.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &ServerInfo{}
 
 // ServerInfo struct for ServerInfo
 type ServerInfo struct {
-	Facility *string `json:"facility,omitempty"`
-	Plan     *string `json:"plan,omitempty"`
-	Quantity *string `json:"quantity,omitempty"`
+	Facility             *string `json:"facility,omitempty"`
+	Plan                 *string `json:"plan,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ServerInfo ServerInfo
 
 // NewServerInfo instantiates a new ServerInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o ServerInfo) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Quantity) {
 		toSerialize["quantity"] = o.Quantity
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ServerInfo) UnmarshalJSON(bytes []byte) (err error) {
+	varServerInfo := _ServerInfo{}
+
+	if err = json.Unmarshal(bytes, &varServerInfo); err == nil {
+		*o = ServerInfo(varServerInfo)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "quantity")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableServerInfo struct {

--- a/metal/v1/model_spot_market_prices_list.go
+++ b/metal/v1/model_spot_market_prices_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotMarketPricesList{}
 
 // SpotMarketPricesList struct for SpotMarketPricesList
 type SpotMarketPricesList struct {
-	SpotMarketPrices *SpotPricesReport `json:"spot_market_prices,omitempty"`
+	SpotMarketPrices     *SpotPricesReport `json:"spot_market_prices,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketPricesList SpotMarketPricesList
 
 // NewSpotMarketPricesList instantiates a new SpotMarketPricesList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotMarketPricesList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.SpotMarketPrices) {
 		toSerialize["spot_market_prices"] = o.SpotMarketPrices
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketPricesList) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketPricesList := _SpotMarketPricesList{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketPricesList); err == nil {
+		*o = SpotMarketPricesList(varSpotMarketPricesList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "spot_market_prices")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketPricesList struct {

--- a/metal/v1/model_spot_market_prices_per_metro_list.go
+++ b/metal/v1/model_spot_market_prices_per_metro_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotMarketPricesPerMetroList{}
 
 // SpotMarketPricesPerMetroList struct for SpotMarketPricesPerMetroList
 type SpotMarketPricesPerMetroList struct {
-	SpotMarketPrices *SpotMarketPricesPerMetroReport `json:"spot_market_prices,omitempty"`
+	SpotMarketPrices     *SpotMarketPricesPerMetroReport `json:"spot_market_prices,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketPricesPerMetroList SpotMarketPricesPerMetroList
 
 // NewSpotMarketPricesPerMetroList instantiates a new SpotMarketPricesPerMetroList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotMarketPricesPerMetroList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.SpotMarketPrices) {
 		toSerialize["spot_market_prices"] = o.SpotMarketPrices
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketPricesPerMetroList) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketPricesPerMetroList := _SpotMarketPricesPerMetroList{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketPricesPerMetroList); err == nil {
+		*o = SpotMarketPricesPerMetroList(varSpotMarketPricesPerMetroList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "spot_market_prices")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketPricesPerMetroList struct {

--- a/metal/v1/model_spot_market_prices_per_metro_report.go
+++ b/metal/v1/model_spot_market_prices_per_metro_report.go
@@ -20,14 +20,17 @@ var _ MappedNullable = &SpotMarketPricesPerMetroReport{}
 
 // SpotMarketPricesPerMetroReport struct for SpotMarketPricesPerMetroReport
 type SpotMarketPricesPerMetroReport struct {
-	Am *SpotPricesPerFacility `json:"am,omitempty"`
-	Ch *SpotPricesPerFacility `json:"ch,omitempty"`
-	Da *SpotPricesPerFacility `json:"da,omitempty"`
-	La *SpotPricesPerFacility `json:"la,omitempty"`
-	Ny *SpotPricesPerFacility `json:"ny,omitempty"`
-	Sg *SpotPricesPerFacility `json:"sg,omitempty"`
-	Sv *SpotPricesPerFacility `json:"sv,omitempty"`
+	Am                   *SpotPricesPerFacility `json:"am,omitempty"`
+	Ch                   *SpotPricesPerFacility `json:"ch,omitempty"`
+	Da                   *SpotPricesPerFacility `json:"da,omitempty"`
+	La                   *SpotPricesPerFacility `json:"la,omitempty"`
+	Ny                   *SpotPricesPerFacility `json:"ny,omitempty"`
+	Sg                   *SpotPricesPerFacility `json:"sg,omitempty"`
+	Sv                   *SpotPricesPerFacility `json:"sv,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketPricesPerMetroReport SpotMarketPricesPerMetroReport
 
 // NewSpotMarketPricesPerMetroReport instantiates a new SpotMarketPricesPerMetroReport object
 // This constructor will assign default values to properties that have it defined,
@@ -301,7 +304,35 @@ func (o SpotMarketPricesPerMetroReport) ToMap() (map[string]interface{}, error) 
 	if !isNil(o.Sv) {
 		toSerialize["sv"] = o.Sv
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketPricesPerMetroReport) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketPricesPerMetroReport := _SpotMarketPricesPerMetroReport{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketPricesPerMetroReport); err == nil {
+		*o = SpotMarketPricesPerMetroReport(varSpotMarketPricesPerMetroReport)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "am")
+		delete(additionalProperties, "ch")
+		delete(additionalProperties, "da")
+		delete(additionalProperties, "la")
+		delete(additionalProperties, "ny")
+		delete(additionalProperties, "sg")
+		delete(additionalProperties, "sv")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketPricesPerMetroReport struct {

--- a/metal/v1/model_spot_market_request.go
+++ b/metal/v1/model_spot_market_request.go
@@ -21,18 +21,21 @@ var _ MappedNullable = &SpotMarketRequest{}
 
 // SpotMarketRequest struct for SpotMarketRequest
 type SpotMarketRequest struct {
-	CreatedAt   *time.Time              `json:"created_at,omitempty"`
-	DevicesMax  *int32                  `json:"devices_max,omitempty"`
-	DevicesMin  *int32                  `json:"devices_min,omitempty"`
-	EndAt       *time.Time              `json:"end_at,omitempty"`
-	Facilities  *Href                   `json:"facilities,omitempty"`
-	Href        *string                 `json:"href,omitempty"`
-	Id          *string                 `json:"id,omitempty"`
-	Instances   *Href                   `json:"instances,omitempty"`
-	MaxBidPrice *float32                `json:"max_bid_price,omitempty"`
-	Metro       *SpotMarketRequestMetro `json:"metro,omitempty"`
-	Project     *Href                   `json:"project,omitempty"`
+	CreatedAt            *time.Time              `json:"created_at,omitempty"`
+	DevicesMax           *int32                  `json:"devices_max,omitempty"`
+	DevicesMin           *int32                  `json:"devices_min,omitempty"`
+	EndAt                *time.Time              `json:"end_at,omitempty"`
+	Facilities           *Href                   `json:"facilities,omitempty"`
+	Href                 *string                 `json:"href,omitempty"`
+	Id                   *string                 `json:"id,omitempty"`
+	Instances            *Href                   `json:"instances,omitempty"`
+	MaxBidPrice          *float32                `json:"max_bid_price,omitempty"`
+	Metro                *SpotMarketRequestMetro `json:"metro,omitempty"`
+	Project              *Href                   `json:"project,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketRequest SpotMarketRequest
 
 // NewSpotMarketRequest instantiates a new SpotMarketRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -446,7 +449,39 @@ func (o SpotMarketRequest) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Project) {
 		toSerialize["project"] = o.Project
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketRequest) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketRequest := _SpotMarketRequest{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketRequest); err == nil {
+		*o = SpotMarketRequest(varSpotMarketRequest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "devices_max")
+		delete(additionalProperties, "devices_min")
+		delete(additionalProperties, "end_at")
+		delete(additionalProperties, "facilities")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "instances")
+		delete(additionalProperties, "max_bid_price")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "project")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketRequest struct {

--- a/metal/v1/model_spot_market_request_create_input.go
+++ b/metal/v1/model_spot_market_request_create_input.go
@@ -28,8 +28,11 @@ type SpotMarketRequestCreateInput struct {
 	InstanceAttributes *SpotMarketRequestCreateInputInstanceAttributes `json:"instance_attributes,omitempty"`
 	MaxBidPrice        *float32                                        `json:"max_bid_price,omitempty"`
 	// The metro ID or code the spot market request will be created in.
-	Metro *string `json:"metro,omitempty"`
+	Metro                *string `json:"metro,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketRequestCreateInput SpotMarketRequestCreateInput
 
 // NewSpotMarketRequestCreateInput instantiates a new SpotMarketRequestCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -303,7 +306,35 @@ func (o SpotMarketRequestCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Metro) {
 		toSerialize["metro"] = o.Metro
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketRequestCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketRequestCreateInput := _SpotMarketRequestCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketRequestCreateInput); err == nil {
+		*o = SpotMarketRequestCreateInput(varSpotMarketRequestCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "devices_max")
+		delete(additionalProperties, "devices_min")
+		delete(additionalProperties, "end_at")
+		delete(additionalProperties, "facilities")
+		delete(additionalProperties, "instance_attributes")
+		delete(additionalProperties, "max_bid_price")
+		delete(additionalProperties, "metro")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketRequestCreateInput struct {

--- a/metal/v1/model_spot_market_request_create_input_instance_attributes.go
+++ b/metal/v1/model_spot_market_request_create_input_instance_attributes.go
@@ -38,9 +38,12 @@ type SpotMarketRequestCreateInputInstanceAttributes struct {
 	Tags                  []string               `json:"tags,omitempty"`
 	TerminationTime       *time.Time             `json:"termination_time,omitempty"`
 	// The UUIDs of users whose SSH keys should be included on the provisioned device.
-	UserSshKeys []string `json:"user_ssh_keys,omitempty"`
-	Userdata    *string  `json:"userdata,omitempty"`
+	UserSshKeys          []string `json:"user_ssh_keys,omitempty"`
+	Userdata             *string  `json:"userdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketRequestCreateInputInstanceAttributes SpotMarketRequestCreateInputInstanceAttributes
 
 // NewSpotMarketRequestCreateInputInstanceAttributes instantiates a new SpotMarketRequestCreateInputInstanceAttributes object
 // This constructor will assign default values to properties that have it defined,
@@ -699,7 +702,46 @@ func (o SpotMarketRequestCreateInputInstanceAttributes) ToMap() (map[string]inte
 	if !isNil(o.Userdata) {
 		toSerialize["userdata"] = o.Userdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketRequestCreateInputInstanceAttributes) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketRequestCreateInputInstanceAttributes := _SpotMarketRequestCreateInputInstanceAttributes{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketRequestCreateInputInstanceAttributes); err == nil {
+		*o = SpotMarketRequestCreateInputInstanceAttributes(varSpotMarketRequestCreateInputInstanceAttributes)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "always_pxe")
+		delete(additionalProperties, "billing_cycle")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "features")
+		delete(additionalProperties, "hostname")
+		delete(additionalProperties, "hostnames")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "no_ssh_keys")
+		delete(additionalProperties, "operating_system")
+		delete(additionalProperties, "plan")
+		delete(additionalProperties, "private_ipv4_subnet_size")
+		delete(additionalProperties, "project_ssh_keys")
+		delete(additionalProperties, "public_ipv4_subnet_size")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "termination_time")
+		delete(additionalProperties, "user_ssh_keys")
+		delete(additionalProperties, "userdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketRequestCreateInputInstanceAttributes struct {

--- a/metal/v1/model_spot_market_request_list.go
+++ b/metal/v1/model_spot_market_request_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotMarketRequestList{}
 
 // SpotMarketRequestList struct for SpotMarketRequestList
 type SpotMarketRequestList struct {
-	SpotMarketRequests []SpotMarketRequest `json:"spot_market_requests,omitempty"`
+	SpotMarketRequests   []SpotMarketRequest `json:"spot_market_requests,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketRequestList SpotMarketRequestList
 
 // NewSpotMarketRequestList instantiates a new SpotMarketRequestList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotMarketRequestList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.SpotMarketRequests) {
 		toSerialize["spot_market_requests"] = o.SpotMarketRequests
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketRequestList) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketRequestList := _SpotMarketRequestList{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketRequestList); err == nil {
+		*o = SpotMarketRequestList(varSpotMarketRequestList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "spot_market_requests")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketRequestList struct {

--- a/metal/v1/model_spot_market_request_metro.go
+++ b/metal/v1/model_spot_market_request_metro.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &SpotMarketRequestMetro{}
 
 // SpotMarketRequestMetro struct for SpotMarketRequestMetro
 type SpotMarketRequestMetro struct {
-	Code    *string `json:"code,omitempty"`
-	Country *string `json:"country,omitempty"`
-	Id      *string `json:"id,omitempty"`
-	Name    *string `json:"name,omitempty"`
+	Code                 *string `json:"code,omitempty"`
+	Country              *string `json:"country,omitempty"`
+	Id                   *string `json:"id,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotMarketRequestMetro SpotMarketRequestMetro
 
 // NewSpotMarketRequestMetro instantiates a new SpotMarketRequestMetro object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,32 @@ func (o SpotMarketRequestMetro) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotMarketRequestMetro) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotMarketRequestMetro := _SpotMarketRequestMetro{}
+
+	if err = json.Unmarshal(bytes, &varSpotMarketRequestMetro); err == nil {
+		*o = SpotMarketRequestMetro(varSpotMarketRequestMetro)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotMarketRequestMetro struct {

--- a/metal/v1/model_spot_prices_datapoints.go
+++ b/metal/v1/model_spot_prices_datapoints.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotPricesDatapoints{}
 
 // SpotPricesDatapoints struct for SpotPricesDatapoints
 type SpotPricesDatapoints struct {
-	Datapoints [][]float32 `json:"datapoints,omitempty"`
+	Datapoints           [][]float32 `json:"datapoints,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotPricesDatapoints SpotPricesDatapoints
 
 // NewSpotPricesDatapoints instantiates a new SpotPricesDatapoints object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotPricesDatapoints) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Datapoints) {
 		toSerialize["datapoints"] = o.Datapoints
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotPricesDatapoints) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotPricesDatapoints := _SpotPricesDatapoints{}
+
+	if err = json.Unmarshal(bytes, &varSpotPricesDatapoints); err == nil {
+		*o = SpotPricesDatapoints(varSpotPricesDatapoints)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "datapoints")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotPricesDatapoints struct {

--- a/metal/v1/model_spot_prices_history_report.go
+++ b/metal/v1/model_spot_prices_history_report.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotPricesHistoryReport{}
 
 // SpotPricesHistoryReport struct for SpotPricesHistoryReport
 type SpotPricesHistoryReport struct {
-	PricesHistory *SpotPricesDatapoints `json:"prices_history,omitempty"`
+	PricesHistory        *SpotPricesDatapoints `json:"prices_history,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotPricesHistoryReport SpotPricesHistoryReport
 
 // NewSpotPricesHistoryReport instantiates a new SpotPricesHistoryReport object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotPricesHistoryReport) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.PricesHistory) {
 		toSerialize["prices_history"] = o.PricesHistory
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotPricesHistoryReport) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotPricesHistoryReport := _SpotPricesHistoryReport{}
+
+	if err = json.Unmarshal(bytes, &varSpotPricesHistoryReport); err == nil {
+		*o = SpotPricesHistoryReport(varSpotPricesHistoryReport)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "prices_history")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotPricesHistoryReport struct {

--- a/metal/v1/model_spot_prices_per_baremetal.go
+++ b/metal/v1/model_spot_prices_per_baremetal.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotPricesPerBaremetal{}
 
 // SpotPricesPerBaremetal struct for SpotPricesPerBaremetal
 type SpotPricesPerBaremetal struct {
-	Price *float32 `json:"price,omitempty"`
+	Price                *float32 `json:"price,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotPricesPerBaremetal SpotPricesPerBaremetal
 
 // NewSpotPricesPerBaremetal instantiates a new SpotPricesPerBaremetal object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotPricesPerBaremetal) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Price) {
 		toSerialize["price"] = o.Price
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotPricesPerBaremetal) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotPricesPerBaremetal := _SpotPricesPerBaremetal{}
+
+	if err = json.Unmarshal(bytes, &varSpotPricesPerBaremetal); err == nil {
+		*o = SpotPricesPerBaremetal(varSpotPricesPerBaremetal)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "price")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotPricesPerBaremetal struct {

--- a/metal/v1/model_spot_prices_per_facility.go
+++ b/metal/v1/model_spot_prices_per_facility.go
@@ -20,16 +20,19 @@ var _ MappedNullable = &SpotPricesPerFacility{}
 
 // SpotPricesPerFacility struct for SpotPricesPerFacility
 type SpotPricesPerFacility struct {
-	Baremetal0   *SpotPricesPerBaremetal `json:"baremetal_0,omitempty"`
-	Baremetal1   *SpotPricesPerBaremetal `json:"baremetal_1,omitempty"`
-	Baremetal2   *SpotPricesPerBaremetal `json:"baremetal_2,omitempty"`
-	Baremetal2a  *SpotPricesPerBaremetal `json:"baremetal_2a,omitempty"`
-	Baremetal2a2 *SpotPricesPerBaremetal `json:"baremetal_2a2,omitempty"`
-	Baremetal3   *SpotPricesPerBaremetal `json:"baremetal_3,omitempty"`
-	BaremetalS   *SpotPricesPerBaremetal `json:"baremetal_s,omitempty"`
-	C2MediumX86  *SpotPricesPerBaremetal `json:"c2.medium.x86,omitempty"`
-	M2XlargeX86  *SpotPricesPerBaremetal `json:"m2.xlarge.x86,omitempty"`
+	Baremetal0           *SpotPricesPerBaremetal `json:"baremetal_0,omitempty"`
+	Baremetal1           *SpotPricesPerBaremetal `json:"baremetal_1,omitempty"`
+	Baremetal2           *SpotPricesPerBaremetal `json:"baremetal_2,omitempty"`
+	Baremetal2a          *SpotPricesPerBaremetal `json:"baremetal_2a,omitempty"`
+	Baremetal2a2         *SpotPricesPerBaremetal `json:"baremetal_2a2,omitempty"`
+	Baremetal3           *SpotPricesPerBaremetal `json:"baremetal_3,omitempty"`
+	BaremetalS           *SpotPricesPerBaremetal `json:"baremetal_s,omitempty"`
+	C2MediumX86          *SpotPricesPerBaremetal `json:"c2.medium.x86,omitempty"`
+	M2XlargeX86          *SpotPricesPerBaremetal `json:"m2.xlarge.x86,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotPricesPerFacility SpotPricesPerFacility
 
 // NewSpotPricesPerFacility instantiates a new SpotPricesPerFacility object
 // This constructor will assign default values to properties that have it defined,
@@ -373,7 +376,37 @@ func (o SpotPricesPerFacility) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.M2XlargeX86) {
 		toSerialize["m2.xlarge.x86"] = o.M2XlargeX86
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotPricesPerFacility) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotPricesPerFacility := _SpotPricesPerFacility{}
+
+	if err = json.Unmarshal(bytes, &varSpotPricesPerFacility); err == nil {
+		*o = SpotPricesPerFacility(varSpotPricesPerFacility)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "baremetal_0")
+		delete(additionalProperties, "baremetal_1")
+		delete(additionalProperties, "baremetal_2")
+		delete(additionalProperties, "baremetal_2a")
+		delete(additionalProperties, "baremetal_2a2")
+		delete(additionalProperties, "baremetal_3")
+		delete(additionalProperties, "baremetal_s")
+		delete(additionalProperties, "c2.medium.x86")
+		delete(additionalProperties, "m2.xlarge.x86")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotPricesPerFacility struct {

--- a/metal/v1/model_spot_prices_per_new_facility.go
+++ b/metal/v1/model_spot_prices_per_new_facility.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SpotPricesPerNewFacility{}
 
 // SpotPricesPerNewFacility struct for SpotPricesPerNewFacility
 type SpotPricesPerNewFacility struct {
-	Baremetal1e *SpotPricesPerBaremetal `json:"baremetal_1e,omitempty"`
+	Baremetal1e          *SpotPricesPerBaremetal `json:"baremetal_1e,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotPricesPerNewFacility SpotPricesPerNewFacility
 
 // NewSpotPricesPerNewFacility instantiates a new SpotPricesPerNewFacility object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SpotPricesPerNewFacility) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Baremetal1e) {
 		toSerialize["baremetal_1e"] = o.Baremetal1e
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotPricesPerNewFacility) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotPricesPerNewFacility := _SpotPricesPerNewFacility{}
+
+	if err = json.Unmarshal(bytes, &varSpotPricesPerNewFacility); err == nil {
+		*o = SpotPricesPerNewFacility(varSpotPricesPerNewFacility)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "baremetal_1e")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotPricesPerNewFacility struct {

--- a/metal/v1/model_spot_prices_report.go
+++ b/metal/v1/model_spot_prices_report.go
@@ -20,21 +20,24 @@ var _ MappedNullable = &SpotPricesReport{}
 
 // SpotPricesReport struct for SpotPricesReport
 type SpotPricesReport struct {
-	Ams1 *SpotPricesPerFacility    `json:"ams1,omitempty"`
-	Atl1 *SpotPricesPerNewFacility `json:"atl1,omitempty"`
-	Dfw1 *SpotPricesPerNewFacility `json:"dfw1,omitempty"`
-	Ewr1 *SpotPricesPerFacility    `json:"ewr1,omitempty"`
-	Fra1 *SpotPricesPerNewFacility `json:"fra1,omitempty"`
-	Iad1 *SpotPricesPerNewFacility `json:"iad1,omitempty"`
-	Lax1 *SpotPricesPerNewFacility `json:"lax1,omitempty"`
-	Nrt1 *SpotPricesPerFacility    `json:"nrt1,omitempty"`
-	Ord1 *SpotPricesPerNewFacility `json:"ord1,omitempty"`
-	Sea1 *SpotPricesPerNewFacility `json:"sea1,omitempty"`
-	Sin1 *SpotPricesPerNewFacility `json:"sin1,omitempty"`
-	Sjc1 *SpotPricesPerFacility    `json:"sjc1,omitempty"`
-	Syd1 *SpotPricesPerNewFacility `json:"syd1,omitempty"`
-	Yyz1 *SpotPricesPerNewFacility `json:"yyz1,omitempty"`
+	Ams1                 *SpotPricesPerFacility    `json:"ams1,omitempty"`
+	Atl1                 *SpotPricesPerNewFacility `json:"atl1,omitempty"`
+	Dfw1                 *SpotPricesPerNewFacility `json:"dfw1,omitempty"`
+	Ewr1                 *SpotPricesPerFacility    `json:"ewr1,omitempty"`
+	Fra1                 *SpotPricesPerNewFacility `json:"fra1,omitempty"`
+	Iad1                 *SpotPricesPerNewFacility `json:"iad1,omitempty"`
+	Lax1                 *SpotPricesPerNewFacility `json:"lax1,omitempty"`
+	Nrt1                 *SpotPricesPerFacility    `json:"nrt1,omitempty"`
+	Ord1                 *SpotPricesPerNewFacility `json:"ord1,omitempty"`
+	Sea1                 *SpotPricesPerNewFacility `json:"sea1,omitempty"`
+	Sin1                 *SpotPricesPerNewFacility `json:"sin1,omitempty"`
+	Sjc1                 *SpotPricesPerFacility    `json:"sjc1,omitempty"`
+	Syd1                 *SpotPricesPerNewFacility `json:"syd1,omitempty"`
+	Yyz1                 *SpotPricesPerNewFacility `json:"yyz1,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SpotPricesReport SpotPricesReport
 
 // NewSpotPricesReport instantiates a new SpotPricesReport object
 // This constructor will assign default values to properties that have it defined,
@@ -553,7 +556,42 @@ func (o SpotPricesReport) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Yyz1) {
 		toSerialize["yyz1"] = o.Yyz1
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SpotPricesReport) UnmarshalJSON(bytes []byte) (err error) {
+	varSpotPricesReport := _SpotPricesReport{}
+
+	if err = json.Unmarshal(bytes, &varSpotPricesReport); err == nil {
+		*o = SpotPricesReport(varSpotPricesReport)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ams1")
+		delete(additionalProperties, "atl1")
+		delete(additionalProperties, "dfw1")
+		delete(additionalProperties, "ewr1")
+		delete(additionalProperties, "fra1")
+		delete(additionalProperties, "iad1")
+		delete(additionalProperties, "lax1")
+		delete(additionalProperties, "nrt1")
+		delete(additionalProperties, "ord1")
+		delete(additionalProperties, "sea1")
+		delete(additionalProperties, "sin1")
+		delete(additionalProperties, "sjc1")
+		delete(additionalProperties, "syd1")
+		delete(additionalProperties, "yyz1")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSpotPricesReport struct {

--- a/metal/v1/model_ssh_key.go
+++ b/metal/v1/model_ssh_key.go
@@ -21,15 +21,18 @@ var _ MappedNullable = &SSHKey{}
 
 // SSHKey struct for SSHKey
 type SSHKey struct {
-	CreatedAt   *time.Time `json:"created_at,omitempty"`
-	Entity      *Href      `json:"entity,omitempty"`
-	Fingerprint *string    `json:"fingerprint,omitempty"`
-	Href        *string    `json:"href,omitempty"`
-	Id          *string    `json:"id,omitempty"`
-	Key         *string    `json:"key,omitempty"`
-	Label       *string    `json:"label,omitempty"`
-	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	Entity               *Href      `json:"entity,omitempty"`
+	Fingerprint          *string    `json:"fingerprint,omitempty"`
+	Href                 *string    `json:"href,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Key                  *string    `json:"key,omitempty"`
+	Label                *string    `json:"label,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SSHKey SSHKey
 
 // NewSSHKey instantiates a new SSHKey object
 // This constructor will assign default values to properties that have it defined,
@@ -338,7 +341,36 @@ func (o SSHKey) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SSHKey) UnmarshalJSON(bytes []byte) (err error) {
+	varSSHKey := _SSHKey{}
+
+	if err = json.Unmarshal(bytes, &varSSHKey); err == nil {
+		*o = SSHKey(varSSHKey)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "entity")
+		delete(additionalProperties, "fingerprint")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "key")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSSHKey struct {

--- a/metal/v1/model_ssh_key_create_input.go
+++ b/metal/v1/model_ssh_key_create_input.go
@@ -21,10 +21,13 @@ var _ MappedNullable = &SSHKeyCreateInput{}
 // SSHKeyCreateInput struct for SSHKeyCreateInput
 type SSHKeyCreateInput struct {
 	// List of instance UUIDs to associate SSH key with, when empty array is sent all instances belonging       to entity will be included
-	InstancesIds []string `json:"instances_ids,omitempty"`
-	Key          *string  `json:"key,omitempty"`
-	Label        *string  `json:"label,omitempty"`
+	InstancesIds         []string `json:"instances_ids,omitempty"`
+	Key                  *string  `json:"key,omitempty"`
+	Label                *string  `json:"label,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SSHKeyCreateInput SSHKeyCreateInput
 
 // NewSSHKeyCreateInput instantiates a new SSHKeyCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -158,7 +161,31 @@ func (o SSHKeyCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Label) {
 		toSerialize["label"] = o.Label
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SSHKeyCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varSSHKeyCreateInput := _SSHKeyCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varSSHKeyCreateInput); err == nil {
+		*o = SSHKeyCreateInput(varSSHKeyCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "instances_ids")
+		delete(additionalProperties, "key")
+		delete(additionalProperties, "label")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSSHKeyCreateInput struct {

--- a/metal/v1/model_ssh_key_input.go
+++ b/metal/v1/model_ssh_key_input.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &SSHKeyInput{}
 
 // SSHKeyInput struct for SSHKeyInput
 type SSHKeyInput struct {
-	Key   *string `json:"key,omitempty"`
-	Label *string `json:"label,omitempty"`
+	Key                  *string `json:"key,omitempty"`
+	Label                *string `json:"label,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SSHKeyInput SSHKeyInput
 
 // NewSSHKeyInput instantiates a new SSHKeyInput object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o SSHKeyInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Label) {
 		toSerialize["label"] = o.Label
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SSHKeyInput) UnmarshalJSON(bytes []byte) (err error) {
+	varSSHKeyInput := _SSHKeyInput{}
+
+	if err = json.Unmarshal(bytes, &varSSHKeyInput); err == nil {
+		*o = SSHKeyInput(varSSHKeyInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "key")
+		delete(additionalProperties, "label")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSSHKeyInput struct {

--- a/metal/v1/model_ssh_key_list.go
+++ b/metal/v1/model_ssh_key_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &SSHKeyList{}
 
 // SSHKeyList struct for SSHKeyList
 type SSHKeyList struct {
-	SshKeys []SSHKey `json:"ssh_keys,omitempty"`
+	SshKeys              []SSHKey `json:"ssh_keys,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SSHKeyList SSHKeyList
 
 // NewSSHKeyList instantiates a new SSHKeyList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o SSHKeyList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.SshKeys) {
 		toSerialize["ssh_keys"] = o.SshKeys
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SSHKeyList) UnmarshalJSON(bytes []byte) (err error) {
+	varSSHKeyList := _SSHKeyList{}
+
+	if err = json.Unmarshal(bytes, &varSSHKeyList); err == nil {
+		*o = SSHKeyList(varSSHKeyList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ssh_keys")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSSHKeyList struct {

--- a/metal/v1/model_storage.go
+++ b/metal/v1/model_storage.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &Storage{}
 
 // Storage struct for Storage
 type Storage struct {
-	Disks       []Disk       `json:"disks,omitempty"`
-	Raid        []Raid       `json:"raid,omitempty"`
-	Filesystems []Filesystem `json:"filesystems,omitempty"`
+	Disks                []Disk       `json:"disks,omitempty"`
+	Raid                 []Raid       `json:"raid,omitempty"`
+	Filesystems          []Filesystem `json:"filesystems,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Storage Storage
 
 // NewStorage instantiates a new Storage object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,31 @@ func (o Storage) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Filesystems) {
 		toSerialize["filesystems"] = o.Filesystems
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Storage) UnmarshalJSON(bytes []byte) (err error) {
+	varStorage := _Storage{}
+
+	if err = json.Unmarshal(bytes, &varStorage); err == nil {
+		*o = Storage(varStorage)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "disks")
+		delete(additionalProperties, "raid")
+		delete(additionalProperties, "filesystems")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableStorage struct {

--- a/metal/v1/model_support_request_input.go
+++ b/metal/v1/model_support_request_input.go
@@ -20,12 +20,15 @@ var _ MappedNullable = &SupportRequestInput{}
 
 // SupportRequestInput struct for SupportRequestInput
 type SupportRequestInput struct {
-	DeviceId  *string `json:"device_id,omitempty"`
-	Message   string  `json:"message"`
-	Priority  *string `json:"priority,omitempty"`
-	ProjectId *string `json:"project_id,omitempty"`
-	Subject   string  `json:"subject"`
+	DeviceId             *string `json:"device_id,omitempty"`
+	Message              string  `json:"message"`
+	Priority             *string `json:"priority,omitempty"`
+	ProjectId            *string `json:"project_id,omitempty"`
+	Subject              string  `json:"subject"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SupportRequestInput SupportRequestInput
 
 // NewSupportRequestInput instantiates a new SupportRequestInput object
 // This constructor will assign default values to properties that have it defined,
@@ -211,7 +214,33 @@ func (o SupportRequestInput) ToMap() (map[string]interface{}, error) {
 		toSerialize["project_id"] = o.ProjectId
 	}
 	toSerialize["subject"] = o.Subject
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SupportRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	varSupportRequestInput := _SupportRequestInput{}
+
+	if err = json.Unmarshal(bytes, &varSupportRequestInput); err == nil {
+		*o = SupportRequestInput(varSupportRequestInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "device_id")
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "priority")
+		delete(additionalProperties, "project_id")
+		delete(additionalProperties, "subject")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSupportRequestInput struct {

--- a/metal/v1/model_transfer_request.go
+++ b/metal/v1/model_transfer_request.go
@@ -21,13 +21,16 @@ var _ MappedNullable = &TransferRequest{}
 
 // TransferRequest struct for TransferRequest
 type TransferRequest struct {
-	CreatedAt          *time.Time `json:"created_at,omitempty"`
-	Href               *string    `json:"href,omitempty"`
-	Id                 *string    `json:"id,omitempty"`
-	Project            *Href      `json:"project,omitempty"`
-	TargetOrganization *Href      `json:"target_organization,omitempty"`
-	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	Href                 *string    `json:"href,omitempty"`
+	Id                   *string    `json:"id,omitempty"`
+	Project              *Href      `json:"project,omitempty"`
+	TargetOrganization   *Href      `json:"target_organization,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TransferRequest TransferRequest
 
 // NewTransferRequest instantiates a new TransferRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -266,7 +269,34 @@ func (o TransferRequest) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TransferRequest) UnmarshalJSON(bytes []byte) (err error) {
+	varTransferRequest := _TransferRequest{}
+
+	if err = json.Unmarshal(bytes, &varTransferRequest); err == nil {
+		*o = TransferRequest(varTransferRequest)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "target_organization")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTransferRequest struct {

--- a/metal/v1/model_transfer_request_input.go
+++ b/metal/v1/model_transfer_request_input.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &TransferRequestInput{}
 // TransferRequestInput struct for TransferRequestInput
 type TransferRequestInput struct {
 	TargetOrganizationId *string `json:"target_organization_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TransferRequestInput TransferRequestInput
 
 // NewTransferRequestInput instantiates a new TransferRequestInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o TransferRequestInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.TargetOrganizationId) {
 		toSerialize["target_organization_id"] = o.TargetOrganizationId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TransferRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	varTransferRequestInput := _TransferRequestInput{}
+
+	if err = json.Unmarshal(bytes, &varTransferRequestInput); err == nil {
+		*o = TransferRequestInput(varTransferRequestInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "target_organization_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTransferRequestInput struct {

--- a/metal/v1/model_transfer_request_list.go
+++ b/metal/v1/model_transfer_request_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &TransferRequestList{}
 
 // TransferRequestList struct for TransferRequestList
 type TransferRequestList struct {
-	Transfers []TransferRequest `json:"transfers,omitempty"`
+	Transfers            []TransferRequest `json:"transfers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TransferRequestList TransferRequestList
 
 // NewTransferRequestList instantiates a new TransferRequestList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o TransferRequestList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Transfers) {
 		toSerialize["transfers"] = o.Transfers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TransferRequestList) UnmarshalJSON(bytes []byte) (err error) {
+	varTransferRequestList := _TransferRequestList{}
+
+	if err = json.Unmarshal(bytes, &varTransferRequestList); err == nil {
+		*o = TransferRequestList(varTransferRequestList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "transfers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTransferRequestList struct {

--- a/metal/v1/model_update_email_input.go
+++ b/metal/v1/model_update_email_input.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &UpdateEmailInput{}
 
 // UpdateEmailInput struct for UpdateEmailInput
 type UpdateEmailInput struct {
-	Default *bool `json:"default,omitempty"`
+	Default              *bool `json:"default,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UpdateEmailInput UpdateEmailInput
 
 // NewUpdateEmailInput instantiates a new UpdateEmailInput object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o UpdateEmailInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Default) {
 		toSerialize["default"] = o.Default
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UpdateEmailInput) UnmarshalJSON(bytes []byte) (err error) {
+	varUpdateEmailInput := _UpdateEmailInput{}
+
+	if err = json.Unmarshal(bytes, &varUpdateEmailInput); err == nil {
+		*o = UpdateEmailInput(varUpdateEmailInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "default")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUpdateEmailInput struct {

--- a/metal/v1/model_user.go
+++ b/metal/v1/model_user.go
@@ -21,27 +21,30 @@ var _ MappedNullable = &User{}
 
 // User struct for User
 type User struct {
-	AvatarThumbUrl   *string                `json:"avatar_thumb_url,omitempty"`
-	AvatarUrl        *string                `json:"avatar_url,omitempty"`
-	CreatedAt        *time.Time             `json:"created_at,omitempty"`
-	Customdata       map[string]interface{} `json:"customdata,omitempty"`
-	Email            *string                `json:"email,omitempty"`
-	Emails           []Href                 `json:"emails,omitempty"`
-	FirstName        *string                `json:"first_name,omitempty"`
-	FraudScore       *string                `json:"fraud_score,omitempty"`
-	FullName         *string                `json:"full_name,omitempty"`
-	Href             *string                `json:"href,omitempty"`
-	Id               *string                `json:"id,omitempty"`
-	LastLoginAt      *time.Time             `json:"last_login_at,omitempty"`
-	LastName         *string                `json:"last_name,omitempty"`
-	MaxOrganizations *int32                 `json:"max_organizations,omitempty"`
-	MaxProjects      *int32                 `json:"max_projects,omitempty"`
-	PhoneNumber      *string                `json:"phone_number,omitempty"`
-	ShortId          *string                `json:"short_id,omitempty"`
-	Timezone         *string                `json:"timezone,omitempty"`
-	TwoFactorAuth    *string                `json:"two_factor_auth,omitempty"`
-	UpdatedAt        *time.Time             `json:"updated_at,omitempty"`
+	AvatarThumbUrl       *string                `json:"avatar_thumb_url,omitempty"`
+	AvatarUrl            *string                `json:"avatar_url,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Email                *string                `json:"email,omitempty"`
+	Emails               []Href                 `json:"emails,omitempty"`
+	FirstName            *string                `json:"first_name,omitempty"`
+	FraudScore           *string                `json:"fraud_score,omitempty"`
+	FullName             *string                `json:"full_name,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   *string                `json:"id,omitempty"`
+	LastLoginAt          *time.Time             `json:"last_login_at,omitempty"`
+	LastName             *string                `json:"last_name,omitempty"`
+	MaxOrganizations     *int32                 `json:"max_organizations,omitempty"`
+	MaxProjects          *int32                 `json:"max_projects,omitempty"`
+	PhoneNumber          *string                `json:"phone_number,omitempty"`
+	ShortId              *string                `json:"short_id,omitempty"`
+	Timezone             *string                `json:"timezone,omitempty"`
+	TwoFactorAuth        *string                `json:"two_factor_auth,omitempty"`
+	UpdatedAt            *time.Time             `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _User User
 
 // NewUser instantiates a new User object
 // This constructor will assign default values to properties that have it defined,
@@ -770,7 +773,48 @@ func (o User) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *User) UnmarshalJSON(bytes []byte) (err error) {
+	varUser := _User{}
+
+	if err = json.Unmarshal(bytes, &varUser); err == nil {
+		*o = User(varUser)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "avatar_thumb_url")
+		delete(additionalProperties, "avatar_url")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "emails")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "fraud_score")
+		delete(additionalProperties, "full_name")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "last_login_at")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "max_organizations")
+		delete(additionalProperties, "max_projects")
+		delete(additionalProperties, "phone_number")
+		delete(additionalProperties, "short_id")
+		delete(additionalProperties, "timezone")
+		delete(additionalProperties, "two_factor_auth")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUser struct {

--- a/metal/v1/model_user_create_input.go
+++ b/metal/v1/model_user_create_input.go
@@ -22,25 +22,28 @@ var _ MappedNullable = &UserCreateInput{}
 
 // UserCreateInput struct for UserCreateInput
 type UserCreateInput struct {
-	Avatar         **os.File              `json:"avatar,omitempty"`
-	CompanyName    *string                `json:"company_name,omitempty"`
-	CompanyUrl     *string                `json:"company_url,omitempty"`
-	Customdata     map[string]interface{} `json:"customdata,omitempty"`
-	Emails         []EmailInput           `json:"emails"`
-	FirstName      string                 `json:"first_name"`
-	LastName       string                 `json:"last_name"`
-	Level          *string                `json:"level,omitempty"`
-	Locked         *bool                  `json:"locked,omitempty"`
-	Password       *string                `json:"password,omitempty"`
-	PhoneNumber    *string                `json:"phone_number,omitempty"`
-	SocialAccounts map[string]interface{} `json:"social_accounts,omitempty"`
-	Timezone       *string                `json:"timezone,omitempty"`
-	Title          *string                `json:"title,omitempty"`
-	TwoFactorAuth  *string                `json:"two_factor_auth,omitempty"`
-	VerifiedAt     *time.Time             `json:"verified_at,omitempty"`
-	InvitationId   *string                `json:"invitation_id,omitempty"`
-	Nonce          *string                `json:"nonce,omitempty"`
+	Avatar               **os.File              `json:"avatar,omitempty"`
+	CompanyName          *string                `json:"company_name,omitempty"`
+	CompanyUrl           *string                `json:"company_url,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Emails               []EmailInput           `json:"emails"`
+	FirstName            string                 `json:"first_name"`
+	LastName             string                 `json:"last_name"`
+	Level                *string                `json:"level,omitempty"`
+	Locked               *bool                  `json:"locked,omitempty"`
+	Password             *string                `json:"password,omitempty"`
+	PhoneNumber          *string                `json:"phone_number,omitempty"`
+	SocialAccounts       map[string]interface{} `json:"social_accounts,omitempty"`
+	Timezone             *string                `json:"timezone,omitempty"`
+	Title                *string                `json:"title,omitempty"`
+	TwoFactorAuth        *string                `json:"two_factor_auth,omitempty"`
+	VerifiedAt           *time.Time             `json:"verified_at,omitempty"`
+	InvitationId         *string                `json:"invitation_id,omitempty"`
+	Nonce                *string                `json:"nonce,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UserCreateInput UserCreateInput
 
 // NewUserCreateInput instantiates a new UserCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -672,7 +675,46 @@ func (o UserCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Nonce) {
 		toSerialize["nonce"] = o.Nonce
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UserCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varUserCreateInput := _UserCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varUserCreateInput); err == nil {
+		*o = UserCreateInput(varUserCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "avatar")
+		delete(additionalProperties, "company_name")
+		delete(additionalProperties, "company_url")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "emails")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "level")
+		delete(additionalProperties, "locked")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "phone_number")
+		delete(additionalProperties, "social_accounts")
+		delete(additionalProperties, "timezone")
+		delete(additionalProperties, "title")
+		delete(additionalProperties, "two_factor_auth")
+		delete(additionalProperties, "verified_at")
+		delete(additionalProperties, "invitation_id")
+		delete(additionalProperties, "nonce")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserCreateInput struct {

--- a/metal/v1/model_user_limited.go
+++ b/metal/v1/model_user_limited.go
@@ -29,8 +29,11 @@ type UserLimited struct {
 	// API URL uniquely representing the User
 	Href *string `json:"href,omitempty"`
 	// ID of the User
-	Id string `json:"id"`
+	Id                   string `json:"id"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UserLimited UserLimited
 
 // NewUserLimited instantiates a new UserLimited object
 // This constructor will assign default values to properties that have it defined,
@@ -225,7 +228,33 @@ func (o UserLimited) ToMap() (map[string]interface{}, error) {
 		toSerialize["href"] = o.Href
 	}
 	toSerialize["id"] = o.Id
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UserLimited) UnmarshalJSON(bytes []byte) (err error) {
+	varUserLimited := _UserLimited{}
+
+	if err = json.Unmarshal(bytes, &varUserLimited); err == nil {
+		*o = UserLimited(varUserLimited)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "avatar_thumb_url")
+		delete(additionalProperties, "avatar_url")
+		delete(additionalProperties, "full_name")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserLimited struct {

--- a/metal/v1/model_user_list.go
+++ b/metal/v1/model_user_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &UserList{}
 
 // UserList struct for UserList
 type UserList struct {
-	Meta  *Meta  `json:"meta,omitempty"`
-	Users []User `json:"users,omitempty"`
+	Meta                 *Meta  `json:"meta,omitempty"`
+	Users                []User `json:"users,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UserList UserList
 
 // NewUserList instantiates a new UserList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o UserList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Users) {
 		toSerialize["users"] = o.Users
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UserList) UnmarshalJSON(bytes []byte) (err error) {
+	varUserList := _UserList{}
+
+	if err = json.Unmarshal(bytes, &varUserList); err == nil {
+		*o = UserList(varUserList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "meta")
+		delete(additionalProperties, "users")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserList struct {

--- a/metal/v1/model_user_lite.go
+++ b/metal/v1/model_user_lite.go
@@ -40,8 +40,11 @@ type UserLite struct {
 	// Short ID of the User
 	ShortId string `json:"short_id"`
 	// When the user details were last updated
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UserLite UserLite
 
 // NewUserLite instantiates a new UserLite object
 // This constructor will assign default values to properties that have it defined,
@@ -402,7 +405,38 @@ func (o UserLite) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UserLite) UnmarshalJSON(bytes []byte) (err error) {
+	varUserLite := _UserLite{}
+
+	if err = json.Unmarshal(bytes, &varUserLite); err == nil {
+		*o = UserLite(varUserLite)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "avatar_thumb_url")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "full_name")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "short_id")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserLite struct {

--- a/metal/v1/model_user_update_input.go
+++ b/metal/v1/model_user_update_input.go
@@ -20,13 +20,16 @@ var _ MappedNullable = &UserUpdateInput{}
 
 // UserUpdateInput struct for UserUpdateInput
 type UserUpdateInput struct {
-	Customdata  map[string]interface{} `json:"customdata,omitempty"`
-	FirstName   *string                `json:"first_name,omitempty"`
-	LastName    *string                `json:"last_name,omitempty"`
-	Password    *string                `json:"password,omitempty"`
-	PhoneNumber *string                `json:"phone_number,omitempty"`
-	Timezone    *string                `json:"timezone,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	FirstName            *string                `json:"first_name,omitempty"`
+	LastName             *string                `json:"last_name,omitempty"`
+	Password             *string                `json:"password,omitempty"`
+	PhoneNumber          *string                `json:"phone_number,omitempty"`
+	Timezone             *string                `json:"timezone,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UserUpdateInput UserUpdateInput
 
 // NewUserUpdateInput instantiates a new UserUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -265,7 +268,34 @@ func (o UserUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Timezone) {
 		toSerialize["timezone"] = o.Timezone
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UserUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varUserUpdateInput := _UserUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varUserUpdateInput); err == nil {
+		*o = UserUpdateInput(varUserUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "phone_number")
+		delete(additionalProperties, "timezone")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserUpdateInput struct {

--- a/metal/v1/model_userdata.go
+++ b/metal/v1/model_userdata.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &Userdata{}
 
 // Userdata struct for Userdata
 type Userdata struct {
-	Userdata *string `json:"userdata,omitempty"`
+	Userdata             *string `json:"userdata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Userdata Userdata
 
 // NewUserdata instantiates a new Userdata object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o Userdata) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Userdata) {
 		toSerialize["userdata"] = o.Userdata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Userdata) UnmarshalJSON(bytes []byte) (err error) {
+	varUserdata := _Userdata{}
+
+	if err = json.Unmarshal(bytes, &varUserdata); err == nil {
+		*o = Userdata(varUserdata)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "userdata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserdata struct {

--- a/metal/v1/model_verify_email.go
+++ b/metal/v1/model_verify_email.go
@@ -21,8 +21,11 @@ var _ MappedNullable = &VerifyEmail{}
 // VerifyEmail struct for VerifyEmail
 type VerifyEmail struct {
 	// User verification token
-	UserToken string `json:"user_token"`
+	UserToken            string `json:"user_token"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VerifyEmail VerifyEmail
 
 // NewVerifyEmail instantiates a new VerifyEmail object
 // This constructor will assign default values to properties that have it defined,
@@ -77,7 +80,29 @@ func (o VerifyEmail) MarshalJSON() ([]byte, error) {
 func (o VerifyEmail) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["user_token"] = o.UserToken
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VerifyEmail) UnmarshalJSON(bytes []byte) (err error) {
+	varVerifyEmail := _VerifyEmail{}
+
+	if err = json.Unmarshal(bytes, &varVerifyEmail); err == nil {
+		*o = VerifyEmail(varVerifyEmail)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "user_token")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVerifyEmail struct {

--- a/metal/v1/model_virtual_circuit.go
+++ b/metal/v1/model_virtual_circuit.go
@@ -32,13 +32,16 @@ type VirtualCircuit struct {
 	// For Virtual Circuits on shared and dedicated connections, this speed should match the one set on their Interconnection Ports. For Virtual Circuits on Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
 	Speed *int32 `json:"speed,omitempty"`
 	// The status of a Virtual Circuit is always 'Pending' on creation. The status can turn to 'Waiting on Customer VLAN' if a Metro VLAN was not set yet on the Virtual Circuit and is the last step needed for full activation. For Dedicated interconnections, as long as the Dedicated Port has been associated to the Virtual Circuit and a NNI VNID has been set, it will turn to 'Waiting on Customer VLAN'. For Fabric VCs, it will only change to 'Waiting on Customer VLAN' once the corresponding Fabric connection has been found on the Fabric side. Once a Metro VLAN is set on the Virtual Circuit (which for Fabric VCs, can be set on creation) and the necessary set up is done, it will turn into 'Activating' status as it tries to activate the Virtual Circuit. Once the Virtual Circuit fully activates and is configured on the switch, it will turn to staus 'Active'. For Fabric VCs (Metal Billed), we will start billing the moment the status of the Virtual Circuit turns to 'Active'. If there are any changes to the VLAN after the Virtual Circuit is in an 'Active' status, the status will show 'Changing VLAN' if a new VLAN has been provided, or 'Deactivating' if we are removing the VLAN. When a deletion request is issued for the Virtual Circuit, it will move to a 'deleting' status until it is fully deleted. If the Virtual Circuit is on a Fabric VC, it can also change into an 'Expired' status if the associated service token has expired.
-	Status         string     `json:"status"`
-	Tags           []string   `json:"tags"`
-	VirtualNetwork Href       `json:"virtual_network"`
-	Vnid           int32      `json:"vnid"`
-	CreatedAt      *time.Time `json:"created_at,omitempty"`
-	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
+	Status               string     `json:"status"`
+	Tags                 []string   `json:"tags"`
+	VirtualNetwork       Href       `json:"virtual_network"`
+	Vnid                 int32      `json:"vnid"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualCircuit VirtualCircuit
 
 // NewVirtualCircuit instantiates a new VirtualCircuit object
 // This constructor will assign default values to properties that have it defined,
@@ -460,7 +463,42 @@ func (o VirtualCircuit) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualCircuit) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualCircuit := _VirtualCircuit{}
+
+	if err = json.Unmarshal(bytes, &varVirtualCircuit); err == nil {
+		*o = VirtualCircuit(varVirtualCircuit)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bill")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "nni_vlan")
+		delete(additionalProperties, "port")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "virtual_network")
+		delete(additionalProperties, "vnid")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualCircuit struct {

--- a/metal/v1/model_virtual_circuit_create_input.go
+++ b/metal/v1/model_virtual_circuit_create_input.go
@@ -28,8 +28,11 @@ type VirtualCircuitCreateInput struct {
 	Speed *int32   `json:"speed,omitempty"`
 	Tags  []string `json:"tags,omitempty"`
 	// A Virtual Network record UUID or the VNID of a Metro Virtual Network in your project (sent as integer).
-	Vnid *string `json:"vnid,omitempty"`
+	Vnid                 *string `json:"vnid,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualCircuitCreateInput VirtualCircuitCreateInput
 
 // NewVirtualCircuitCreateInput instantiates a new VirtualCircuitCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -294,7 +297,35 @@ func (o VirtualCircuitCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vnid) {
 		toSerialize["vnid"] = o.Vnid
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualCircuitCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualCircuitCreateInput := _VirtualCircuitCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVirtualCircuitCreateInput); err == nil {
+		*o = VirtualCircuitCreateInput(varVirtualCircuitCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "nni_vlan")
+		delete(additionalProperties, "project_id")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "vnid")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualCircuitCreateInput struct {

--- a/metal/v1/model_virtual_circuit_list.go
+++ b/metal/v1/model_virtual_circuit_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &VirtualCircuitList{}
 
 // VirtualCircuitList struct for VirtualCircuitList
 type VirtualCircuitList struct {
-	VirtualCircuits []VirtualCircuitListVirtualCircuitsInner `json:"virtual_circuits,omitempty"`
+	VirtualCircuits      []VirtualCircuitListVirtualCircuitsInner `json:"virtual_circuits,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualCircuitList VirtualCircuitList
 
 // NewVirtualCircuitList instantiates a new VirtualCircuitList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o VirtualCircuitList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.VirtualCircuits) {
 		toSerialize["virtual_circuits"] = o.VirtualCircuits
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualCircuitList) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualCircuitList := _VirtualCircuitList{}
+
+	if err = json.Unmarshal(bytes, &varVirtualCircuitList); err == nil {
+		*o = VirtualCircuitList(varVirtualCircuitList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "virtual_circuits")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualCircuitList struct {

--- a/metal/v1/model_virtual_circuit_update_input.go
+++ b/metal/v1/model_virtual_circuit_update_input.go
@@ -26,8 +26,11 @@ type VirtualCircuitUpdateInput struct {
 	Speed *string  `json:"speed,omitempty"`
 	Tags  []string `json:"tags,omitempty"`
 	// A Virtual Network record UUID or the VNID of a Metro Virtual Network in your project.
-	Vnid *string `json:"vnid,omitempty"`
+	Vnid                 *string `json:"vnid,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualCircuitUpdateInput VirtualCircuitUpdateInput
 
 // NewVirtualCircuitUpdateInput instantiates a new VirtualCircuitUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -231,7 +234,33 @@ func (o VirtualCircuitUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vnid) {
 		toSerialize["vnid"] = o.Vnid
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualCircuitUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualCircuitUpdateInput := _VirtualCircuitUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varVirtualCircuitUpdateInput); err == nil {
+		*o = VirtualCircuitUpdateInput(varVirtualCircuitUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "vnid")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualCircuitUpdateInput struct {

--- a/metal/v1/model_virtual_network.go
+++ b/metal/v1/model_virtual_network.go
@@ -33,9 +33,12 @@ type VirtualNetwork struct {
 	MetalGateways []MetalGatewayLite `json:"metal_gateways,omitempty"`
 	Metro         *Href              `json:"metro,omitempty"`
 	// The Metro code of the metro in which this Virtual Network is defined.
-	MetroCode *string `json:"metro_code,omitempty"`
-	Vxlan     *int32  `json:"vxlan,omitempty"`
+	MetroCode            *string `json:"metro_code,omitempty"`
+	Vxlan                *int32  `json:"vxlan,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualNetwork VirtualNetwork
 
 // NewVirtualNetwork instantiates a new VirtualNetwork object
 // This constructor will assign default values to properties that have it defined,
@@ -449,7 +452,39 @@ func (o VirtualNetwork) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vxlan) {
 		toSerialize["vxlan"] = o.Vxlan
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualNetwork) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualNetwork := _VirtualNetwork{}
+
+	if err = json.Unmarshal(bytes, &varVirtualNetwork); err == nil {
+		*o = VirtualNetwork(varVirtualNetwork)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "assigned_to")
+		delete(additionalProperties, "assigned_to_virtual_circuit")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "instances")
+		delete(additionalProperties, "metal_gateways")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "metro_code")
+		delete(additionalProperties, "vxlan")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualNetwork struct {

--- a/metal/v1/model_virtual_network_create_input.go
+++ b/metal/v1/model_virtual_network_create_input.go
@@ -26,8 +26,11 @@ type VirtualNetworkCreateInput struct {
 	// The UUID (or metro code) for the Metro in which to create this Virtual Network.
 	Metro *string `json:"metro,omitempty"`
 	// VLAN ID between 2-3999. Must be unique for the project within the Metro in which this Virtual Network is being created. If no value is specified, the next-available VLAN ID in the range 1000-1999 will be automatically selected.
-	Vxlan *int32 `json:"vxlan,omitempty"`
+	Vxlan                *int32 `json:"vxlan,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualNetworkCreateInput VirtualNetworkCreateInput
 
 // NewVirtualNetworkCreateInput instantiates a new VirtualNetworkCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -196,7 +199,32 @@ func (o VirtualNetworkCreateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vxlan) {
 		toSerialize["vxlan"] = o.Vxlan
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualNetworkCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualNetworkCreateInput := _VirtualNetworkCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVirtualNetworkCreateInput); err == nil {
+		*o = VirtualNetworkCreateInput(varVirtualNetworkCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "facility")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "vxlan")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualNetworkCreateInput struct {

--- a/metal/v1/model_virtual_network_list.go
+++ b/metal/v1/model_virtual_network_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &VirtualNetworkList{}
 
 // VirtualNetworkList struct for VirtualNetworkList
 type VirtualNetworkList struct {
-	VirtualNetworks []VirtualNetwork `json:"virtual_networks,omitempty"`
+	VirtualNetworks      []VirtualNetwork `json:"virtual_networks,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VirtualNetworkList VirtualNetworkList
 
 // NewVirtualNetworkList instantiates a new VirtualNetworkList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o VirtualNetworkList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.VirtualNetworks) {
 		toSerialize["virtual_networks"] = o.VirtualNetworks
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VirtualNetworkList) UnmarshalJSON(bytes []byte) (err error) {
+	varVirtualNetworkList := _VirtualNetworkList{}
+
+	if err = json.Unmarshal(bytes, &varVirtualNetworkList); err == nil {
+		*o = VirtualNetworkList(varVirtualNetworkList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "virtual_networks")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVirtualNetworkList struct {

--- a/metal/v1/model_vrf.go
+++ b/metal/v1/model_vrf.go
@@ -32,14 +32,17 @@ type Vrf struct {
 	// A 4-byte ASN associated with the VRF.
 	LocalAsn *int32 `json:"local_asn,omitempty"`
 	// A list of CIDR network addresses. Like [\"10.0.0.0/16\", \"2001:d78::/56\"].
-	IpRanges  []string   `json:"ip_ranges,omitempty"`
-	Project   *Project   `json:"project,omitempty"`
-	Metro     *Metro     `json:"metro,omitempty"`
-	CreatedBy *User      `json:"created_by,omitempty"`
-	Href      *string    `json:"href,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	IpRanges             []string   `json:"ip_ranges,omitempty"`
+	Project              *Project   `json:"project,omitempty"`
+	Metro                *Metro     `json:"metro,omitempty"`
+	CreatedBy            *User      `json:"created_by,omitempty"`
+	Href                 *string    `json:"href,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Vrf Vrf
 
 // NewVrf instantiates a new Vrf object
 // This constructor will assign default values to properties that have it defined,
@@ -523,7 +526,41 @@ func (o Vrf) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Vrf) UnmarshalJSON(bytes []byte) (err error) {
+	varVrf := _Vrf{}
+
+	if err = json.Unmarshal(bytes, &varVrf); err == nil {
+		*o = Vrf(varVrf)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "bgp_dynamic_neighbors_enabled")
+		delete(additionalProperties, "bgp_dynamic_neighbors_export_route_map")
+		delete(additionalProperties, "local_asn")
+		delete(additionalProperties, "ip_ranges")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "created_by")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrf struct {

--- a/metal/v1/model_vrf_create_input.go
+++ b/metal/v1/model_vrf_create_input.go
@@ -25,9 +25,12 @@ type VrfCreateInput struct {
 	IpRanges []string `json:"ip_ranges,omitempty"`
 	LocalAsn *int32   `json:"local_asn,omitempty"`
 	// The UUID (or metro code) for the Metro in which to create this VRF.
-	Metro string `json:"metro"`
-	Name  string `json:"name"`
+	Metro                string `json:"metro"`
+	Name                 string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfCreateInput VrfCreateInput
 
 // NewVrfCreateInput instantiates a new VrfCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -213,7 +216,33 @@ func (o VrfCreateInput) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["metro"] = o.Metro
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfCreateInput := _VrfCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfCreateInput); err == nil {
+		*o = VrfCreateInput(varVrfCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "ip_ranges")
+		delete(additionalProperties, "local_asn")
+		delete(additionalProperties, "metro")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfCreateInput struct {

--- a/metal/v1/model_vrf_ip_reservation.go
+++ b/metal/v1/model_vrf_ip_reservation.go
@@ -21,31 +21,34 @@ var _ MappedNullable = &VrfIpReservation{}
 
 // VrfIpReservation struct for VrfIpReservation
 type VrfIpReservation struct {
-	AddressFamily *int32                 `json:"address_family,omitempty"`
-	Cidr          *int32                 `json:"cidr,omitempty"`
-	CreatedAt     *time.Time             `json:"created_at,omitempty"`
-	CreatedBy     *Href                  `json:"created_by,omitempty"`
-	Details       *string                `json:"details,omitempty"`
-	Href          *string                `json:"href,omitempty"`
-	Id            *string                `json:"id,omitempty"`
-	MetalGateway  *MetalGatewayLite      `json:"metal_gateway,omitempty"`
-	Netmask       *string                `json:"netmask,omitempty"`
-	Network       *string                `json:"network,omitempty"`
-	Project       *Project               `json:"project,omitempty"`
-	State         *string                `json:"state,omitempty"`
-	Tags          []string               `json:"tags,omitempty"`
-	Type          string                 `json:"type"`
-	Vrf           Vrf                    `json:"vrf"`
-	Public        *bool                  `json:"public,omitempty"`
-	Management    *bool                  `json:"management,omitempty"`
-	Manageable    *bool                  `json:"manageable,omitempty"`
-	Customdata    map[string]interface{} `json:"customdata,omitempty"`
-	Bill          *bool                  `json:"bill,omitempty"`
-	ProjectLite   *Project               `json:"project_lite,omitempty"`
-	Address       *string                `json:"address,omitempty"`
-	Gateway       *string                `json:"gateway,omitempty"`
-	Metro         *Metro                 `json:"metro,omitempty"`
+	AddressFamily        *int32                 `json:"address_family,omitempty"`
+	Cidr                 *int32                 `json:"cidr,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	CreatedBy            *Href                  `json:"created_by,omitempty"`
+	Details              *string                `json:"details,omitempty"`
+	Href                 *string                `json:"href,omitempty"`
+	Id                   *string                `json:"id,omitempty"`
+	MetalGateway         *MetalGatewayLite      `json:"metal_gateway,omitempty"`
+	Netmask              *string                `json:"netmask,omitempty"`
+	Network              *string                `json:"network,omitempty"`
+	Project              *Project               `json:"project,omitempty"`
+	State                *string                `json:"state,omitempty"`
+	Tags                 []string               `json:"tags,omitempty"`
+	Type                 string                 `json:"type"`
+	Vrf                  Vrf                    `json:"vrf"`
+	Public               *bool                  `json:"public,omitempty"`
+	Management           *bool                  `json:"management,omitempty"`
+	Manageable           *bool                  `json:"manageable,omitempty"`
+	Customdata           map[string]interface{} `json:"customdata,omitempty"`
+	Bill                 *bool                  `json:"bill,omitempty"`
+	ProjectLite          *Project               `json:"project_lite,omitempty"`
+	Address              *string                `json:"address,omitempty"`
+	Gateway              *string                `json:"gateway,omitempty"`
+	Metro                *Metro                 `json:"metro,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfIpReservation VrfIpReservation
 
 // NewVrfIpReservation instantiates a new VrfIpReservation object
 // This constructor will assign default values to properties that have it defined,
@@ -896,7 +899,52 @@ func (o VrfIpReservation) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Metro) {
 		toSerialize["metro"] = o.Metro
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfIpReservation) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfIpReservation := _VrfIpReservation{}
+
+	if err = json.Unmarshal(bytes, &varVrfIpReservation); err == nil {
+		*o = VrfIpReservation(varVrfIpReservation)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "address_family")
+		delete(additionalProperties, "cidr")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "created_by")
+		delete(additionalProperties, "details")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "metal_gateway")
+		delete(additionalProperties, "netmask")
+		delete(additionalProperties, "network")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "vrf")
+		delete(additionalProperties, "public")
+		delete(additionalProperties, "management")
+		delete(additionalProperties, "manageable")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "bill")
+		delete(additionalProperties, "project_lite")
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "gateway")
+		delete(additionalProperties, "metro")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfIpReservation struct {

--- a/metal/v1/model_vrf_ip_reservation_create_input.go
+++ b/metal/v1/model_vrf_ip_reservation_create_input.go
@@ -30,8 +30,11 @@ type VrfIpReservationCreateInput struct {
 	// Must be set to 'vrf'
 	Type string `json:"type"`
 	// The ID of the VRF in which this VRF IP Reservation is created. The VRF must have an existing IP Range that contains the requested subnet. This field may be aliased as just 'vrf'.
-	VrfId string `json:"vrf_id"`
+	VrfId                string `json:"vrf_id"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfIpReservationCreateInput VrfIpReservationCreateInput
 
 // NewVrfIpReservationCreateInput instantiates a new VrfIpReservationCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -269,7 +272,35 @@ func (o VrfIpReservationCreateInput) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["type"] = o.Type
 	toSerialize["vrf_id"] = o.VrfId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfIpReservationCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfIpReservationCreateInput := _VrfIpReservationCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfIpReservationCreateInput); err == nil {
+		*o = VrfIpReservationCreateInput(varVrfIpReservationCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "cidr")
+		delete(additionalProperties, "customdata")
+		delete(additionalProperties, "details")
+		delete(additionalProperties, "network")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "vrf_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfIpReservationCreateInput struct {

--- a/metal/v1/model_vrf_ip_reservation_list.go
+++ b/metal/v1/model_vrf_ip_reservation_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &VrfIpReservationList{}
 
 // VrfIpReservationList struct for VrfIpReservationList
 type VrfIpReservationList struct {
-	IpAddresses []VrfIpReservation `json:"ip_addresses,omitempty"`
+	IpAddresses          []VrfIpReservation `json:"ip_addresses,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfIpReservationList VrfIpReservationList
 
 // NewVrfIpReservationList instantiates a new VrfIpReservationList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o VrfIpReservationList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.IpAddresses) {
 		toSerialize["ip_addresses"] = o.IpAddresses
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfIpReservationList) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfIpReservationList := _VrfIpReservationList{}
+
+	if err = json.Unmarshal(bytes, &varVrfIpReservationList); err == nil {
+		*o = VrfIpReservationList(varVrfIpReservationList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ip_addresses")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfIpReservationList struct {

--- a/metal/v1/model_vrf_list.go
+++ b/metal/v1/model_vrf_list.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &VrfList{}
 
 // VrfList struct for VrfList
 type VrfList struct {
-	Vrfs []Vrf `json:"vrfs,omitempty"`
+	Vrfs                 []Vrf `json:"vrfs,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfList VrfList
 
 // NewVrfList instantiates a new VrfList object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,29 @@ func (o VrfList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vrfs) {
 		toSerialize["vrfs"] = o.Vrfs
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfList) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfList := _VrfList{}
+
+	if err = json.Unmarshal(bytes, &varVrfList); err == nil {
+		*o = VrfList(varVrfList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "vrfs")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfList struct {

--- a/metal/v1/model_vrf_metal_gateway.go
+++ b/metal/v1/model_vrf_metal_gateway.go
@@ -28,11 +28,14 @@ type VrfMetalGateway struct {
 	IpReservation *VrfIpReservation `json:"ip_reservation,omitempty"`
 	Project       *Project          `json:"project,omitempty"`
 	// The current state of the Metal Gateway. 'Ready' indicates the gateway record has been configured, but is currently not active on the network. 'Active' indicates the gateway has been configured on the network. 'Deleting' is a temporary state used to indicate that the gateway is in the process of being un-configured from the network, after which the gateway record will be deleted.
-	State          *string         `json:"state,omitempty"`
-	UpdatedAt      *time.Time      `json:"updated_at,omitempty"`
-	VirtualNetwork *VirtualNetwork `json:"virtual_network,omitempty"`
-	Vrf            *Vrf            `json:"vrf,omitempty"`
+	State                *string         `json:"state,omitempty"`
+	UpdatedAt            *time.Time      `json:"updated_at,omitempty"`
+	VirtualNetwork       *VirtualNetwork `json:"virtual_network,omitempty"`
+	Vrf                  *Vrf            `json:"vrf,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfMetalGateway VrfMetalGateway
 
 // NewVrfMetalGateway instantiates a new VrfMetalGateway object
 // This constructor will assign default values to properties that have it defined,
@@ -411,7 +414,38 @@ func (o VrfMetalGateway) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Vrf) {
 		toSerialize["vrf"] = o.Vrf
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfMetalGateway) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfMetalGateway := _VrfMetalGateway{}
+
+	if err = json.Unmarshal(bytes, &varVrfMetalGateway); err == nil {
+		*o = VrfMetalGateway(varVrfMetalGateway)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "created_by")
+		delete(additionalProperties, "href")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "ip_reservation")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "virtual_network")
+		delete(additionalProperties, "vrf")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfMetalGateway struct {

--- a/metal/v1/model_vrf_metal_gateway_create_input.go
+++ b/metal/v1/model_vrf_metal_gateway_create_input.go
@@ -23,8 +23,11 @@ type VrfMetalGatewayCreateInput struct {
 	// The UUID an a VRF IP Reservation that belongs to the same project as the one in which the Metal Gateway is to be created. Additionally, the VRF IP Reservation and the Virtual Network must reside in the same Metro.
 	IpReservationId string `json:"ip_reservation_id"`
 	// THe UUID of a Metro Virtual Network that belongs to the same project as the one in which the Metal Gateway is to be created. Additionally, the Virtual Network and the VRF IP Reservation must reside in the same metro.
-	VirtualNetworkId string `json:"virtual_network_id"`
+	VirtualNetworkId     string `json:"virtual_network_id"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfMetalGatewayCreateInput VrfMetalGatewayCreateInput
 
 // NewVrfMetalGatewayCreateInput instantiates a new VrfMetalGatewayCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -105,7 +108,30 @@ func (o VrfMetalGatewayCreateInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["ip_reservation_id"] = o.IpReservationId
 	toSerialize["virtual_network_id"] = o.VirtualNetworkId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfMetalGatewayCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfMetalGatewayCreateInput := _VrfMetalGatewayCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfMetalGatewayCreateInput); err == nil {
+		*o = VrfMetalGatewayCreateInput(varVrfMetalGatewayCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "ip_reservation_id")
+		delete(additionalProperties, "virtual_network_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfMetalGatewayCreateInput struct {

--- a/metal/v1/model_vrf_route.go
+++ b/metal/v1/model_vrf_route.go
@@ -30,14 +30,17 @@ type VrfRoute struct {
 	// The next-hop IPv4 address for the route
 	NextHop *string `json:"next_hop,omitempty"`
 	// VRF route type, like 'bgp', 'connected', and 'static'. Currently, only static routes are supported
-	Type           *string                 `json:"type,omitempty"`
-	CreatedAt      *time.Time              `json:"created_at,omitempty"`
-	UpdatedAt      *time.Time              `json:"updated_at,omitempty"`
-	MetalGateway   *VrfRouteMetalGateway   `json:"metal_gateway,omitempty"`
-	VirtualNetwork *VrfRouteVirtualNetwork `json:"virtual_network,omitempty"`
-	Vrf            *VrfRouteVrf            `json:"vrf,omitempty"`
-	Href           *string                 `json:"href,omitempty"`
+	Type                 *string                 `json:"type,omitempty"`
+	CreatedAt            *time.Time              `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time              `json:"updated_at,omitempty"`
+	MetalGateway         *VrfRouteMetalGateway   `json:"metal_gateway,omitempty"`
+	VirtualNetwork       *VrfRouteVirtualNetwork `json:"virtual_network,omitempty"`
+	Vrf                  *VrfRouteVrf            `json:"vrf,omitempty"`
+	Href                 *string                 `json:"href,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfRoute VrfRoute
 
 // NewVrfRoute instantiates a new VrfRoute object
 // This constructor will assign default values to properties that have it defined,
@@ -439,7 +442,39 @@ func (o VrfRoute) ToMap() (map[string]interface{}, error) {
 		toSerialize["vrf"] = o.Vrf
 	}
 	// skip: href is readOnly
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfRoute) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfRoute := _VrfRoute{}
+
+	if err = json.Unmarshal(bytes, &varVrfRoute); err == nil {
+		*o = VrfRoute(varVrfRoute)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "prefix")
+		delete(additionalProperties, "next_hop")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "metal_gateway")
+		delete(additionalProperties, "virtual_network")
+		delete(additionalProperties, "vrf")
+		delete(additionalProperties, "href")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfRoute struct {

--- a/metal/v1/model_vrf_route_create_input.go
+++ b/metal/v1/model_vrf_route_create_input.go
@@ -23,8 +23,11 @@ type VrfRouteCreateInput struct {
 	// The IPv4 prefix for the route, in CIDR-style notation. For a static default route, this will always be \"0.0.0.0/0\"
 	Prefix string `json:"prefix"`
 	// The IPv4 address within the VRF of the host that will handle this route
-	NextHop string `json:"next_hop"`
+	NextHop              string `json:"next_hop"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfRouteCreateInput VrfRouteCreateInput
 
 // NewVrfRouteCreateInput instantiates a new VrfRouteCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -105,7 +108,30 @@ func (o VrfRouteCreateInput) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["prefix"] = o.Prefix
 	toSerialize["next_hop"] = o.NextHop
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfRouteCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfRouteCreateInput := _VrfRouteCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfRouteCreateInput); err == nil {
+		*o = VrfRouteCreateInput(varVrfRouteCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "prefix")
+		delete(additionalProperties, "next_hop")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfRouteCreateInput struct {

--- a/metal/v1/model_vrf_route_list.go
+++ b/metal/v1/model_vrf_route_list.go
@@ -20,9 +20,12 @@ var _ MappedNullable = &VrfRouteList{}
 
 // VrfRouteList struct for VrfRouteList
 type VrfRouteList struct {
-	Routes []VrfRoute `json:"routes,omitempty"`
-	Meta   *Meta      `json:"meta,omitempty"`
+	Routes               []VrfRoute `json:"routes,omitempty"`
+	Meta                 *Meta      `json:"meta,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfRouteList VrfRouteList
 
 // NewVrfRouteList instantiates a new VrfRouteList object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,30 @@ func (o VrfRouteList) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Meta) {
 		toSerialize["meta"] = o.Meta
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfRouteList) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfRouteList := _VrfRouteList{}
+
+	if err = json.Unmarshal(bytes, &varVrfRouteList); err == nil {
+		*o = VrfRouteList(varVrfRouteList)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "routes")
+		delete(additionalProperties, "meta")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfRouteList struct {

--- a/metal/v1/model_vrf_update_input.go
+++ b/metal/v1/model_vrf_update_input.go
@@ -28,9 +28,12 @@ type VrfUpdateInput struct {
 	// A list of CIDR network addresses. Like [\"10.0.0.0/16\", \"2001:d78::/56\"]. IPv4 blocks must be between /8 and /29 in size. IPv6 blocks must be between /56 and /64. A VRF\\'s IP ranges must be defined in order to create VRF IP Reservations, which can then be used for Metal Gateways or Virtual Circuits. Adding a new CIDR address to the list will result in the creation of a new IP Range for this VRF. Removal of an existing CIDR address from the list will result in the deletion of an existing IP Range for this VRF. Deleting an IP Range will result in the deletion of any VRF IP Reservations contained within the IP Range, as well as the VRF IP Reservation\\'s associated Metal Gateways or Virtual Circuits. If you do not wish to add or remove IP Ranges, either include the full existing list of IP Ranges in the update request, or do not specify the `ip_ranges` field in the update request. Specifying a value of `[]` will remove all existing IP Ranges from the VRF.
 	IpRanges []string `json:"ip_ranges,omitempty"`
 	// The new `local_asn` value for the VRF. This field cannot be updated when there are active Interconnection Virtual Circuits associated to the VRF.
-	LocalAsn *int32  `json:"local_asn,omitempty"`
-	Name     *string `json:"name,omitempty"`
+	LocalAsn             *int32  `json:"local_asn,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfUpdateInput VrfUpdateInput
 
 // NewVrfUpdateInput instantiates a new VrfUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -269,7 +272,34 @@ func (o VrfUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfUpdateInput := _VrfUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfUpdateInput); err == nil {
+		*o = VrfUpdateInput(varVrfUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "bgp_dynamic_neighbors_enabled")
+		delete(additionalProperties, "bgp_dynamic_neighbors_export_route_map")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "ip_ranges")
+		delete(additionalProperties, "local_asn")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfUpdateInput struct {

--- a/metal/v1/model_vrf_virtual_circuit.go
+++ b/metal/v1/model_vrf_virtual_circuit.go
@@ -39,12 +39,15 @@ type VrfVirtualCircuit struct {
 	Speed  *int32  `json:"speed,omitempty"`
 	Status *string `json:"status,omitempty"`
 	// The /30 or /31 subnet of one of the VRF IP Blocks that will be used with the VRF for the Virtual Circuit. This subnet does not have to be an existing VRF IP reservation, as we will create the VRF IP reservation on creation if it does not exist. The Metal IP and Customer IP must be IPs from this subnet. For /30 subnets, the network and broadcast IPs cannot be used as the Metal or Customer IP.
-	Subnet    *string    `json:"subnet,omitempty"`
-	Tags      []string   `json:"tags,omitempty"`
-	Vrf       *Vrf       `json:"vrf,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	Subnet               *string    `json:"subnet,omitempty"`
+	Tags                 []string   `json:"tags,omitempty"`
+	Vrf                  *Vrf       `json:"vrf,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfVirtualCircuit VrfVirtualCircuit
 
 // NewVrfVirtualCircuit instantiates a new VrfVirtualCircuit object
 // This constructor will assign default values to properties that have it defined,
@@ -668,7 +671,45 @@ func (o VrfVirtualCircuit) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfVirtualCircuit) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfVirtualCircuit := _VrfVirtualCircuit{}
+
+	if err = json.Unmarshal(bytes, &varVrfVirtualCircuit); err == nil {
+		*o = VrfVirtualCircuit(varVrfVirtualCircuit)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customer_ip")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "md5")
+		delete(additionalProperties, "metal_ip")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "port")
+		delete(additionalProperties, "nni_vlan")
+		delete(additionalProperties, "peer_asn")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "subnet")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "vrf")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfVirtualCircuit struct {

--- a/metal/v1/model_vrf_virtual_circuit_create_input.go
+++ b/metal/v1/model_vrf_virtual_circuit_create_input.go
@@ -38,8 +38,11 @@ type VrfVirtualCircuitCreateInput struct {
 	Subnet string   `json:"subnet"`
 	Tags   []string `json:"tags,omitempty"`
 	// The UUID of the VRF that will be associated with the Virtual Circuit.
-	Vrf string `json:"vrf"`
+	Vrf                  string `json:"vrf"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfVirtualCircuitCreateInput VrfVirtualCircuitCreateInput
 
 // NewVrfVirtualCircuitCreateInput instantiates a new VrfVirtualCircuitCreateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -454,7 +457,40 @@ func (o VrfVirtualCircuitCreateInput) ToMap() (map[string]interface{}, error) {
 		toSerialize["tags"] = o.Tags
 	}
 	toSerialize["vrf"] = o.Vrf
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfVirtualCircuitCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfVirtualCircuitCreateInput := _VrfVirtualCircuitCreateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfVirtualCircuitCreateInput); err == nil {
+		*o = VrfVirtualCircuitCreateInput(varVrfVirtualCircuitCreateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customer_ip")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "md5")
+		delete(additionalProperties, "metal_ip")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "nni_vlan")
+		delete(additionalProperties, "peer_asn")
+		delete(additionalProperties, "project_id")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "subnet")
+		delete(additionalProperties, "tags")
+		delete(additionalProperties, "vrf")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfVirtualCircuitCreateInput struct {

--- a/metal/v1/model_vrf_virtual_circuit_update_input.go
+++ b/metal/v1/model_vrf_virtual_circuit_update_input.go
@@ -33,9 +33,12 @@ type VrfVirtualCircuitUpdateInput struct {
 	// Speed can be changed only if it is an interconnection on a Dedicated Port
 	Speed *string `json:"speed,omitempty"`
 	// The /30 or /31 subnet of one of the VRF IP Blocks that will be used with the VRF for the Virtual Circuit. This subnet does not have to be an existing VRF IP reservation, as we will create the VRF IP reservation on creation if it does not exist. The Metal IP and Customer IP must be IPs from this subnet. For /30 subnets, the network and broadcast IPs cannot be used as the Metal or Customer IP.
-	Subnet *string  `json:"subnet,omitempty"`
-	Tags   []string `json:"tags,omitempty"`
+	Subnet               *string  `json:"subnet,omitempty"`
+	Tags                 []string `json:"tags,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _VrfVirtualCircuitUpdateInput VrfVirtualCircuitUpdateInput
 
 // NewVrfVirtualCircuitUpdateInput instantiates a new VrfVirtualCircuitUpdateInput object
 // This constructor will assign default values to properties that have it defined,
@@ -379,7 +382,37 @@ func (o VrfVirtualCircuitUpdateInput) ToMap() (map[string]interface{}, error) {
 	if !isNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *VrfVirtualCircuitUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
+	varVrfVirtualCircuitUpdateInput := _VrfVirtualCircuitUpdateInput{}
+
+	if err = json.Unmarshal(bytes, &varVrfVirtualCircuitUpdateInput); err == nil {
+		*o = VrfVirtualCircuitUpdateInput(varVrfVirtualCircuitUpdateInput)
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		delete(additionalProperties, "customer_ip")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "md5")
+		delete(additionalProperties, "metal_ip")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "peer_asn")
+		delete(additionalProperties, "speed")
+		delete(additionalProperties, "subnet")
+		delete(additionalProperties, "tags")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableVrfVirtualCircuitUpdateInput struct {


### PR DESCRIPTION
In order to ensure that the code we generate behaves according to the OpenAPI specification, we need to set `disallowAdditionalPropertiesIfNotPresent` to `false`.

The OpenAPI specification is built on top of the JSON schema spec. In the JSON schema spec, `additionalProperties` defaults to `true` in order to maximize forward compability: a client library should not break because a new property was added to an response.

The default behavior of the OpenAPI generator is to generate code that does not provide access to `additionalProperties`, and that validates API responses inconsistently (in, e.g., `oneOf` schemas, additional properties will fail validation, but passing the same JSON to the same model outside of a `oneOf` will pass validation).

Generating code according to the OpenAPI spec makes our code more predictable and forces us to document any restrictions on additional properties in our API spec.

Fixes #82 