### PR TITLE
feat: log sunset & deprecation headers

### DIFF
--- a/metal/v1/client.go
+++ b/metal/v1/client.go
@@ -362,6 +362,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 
+	dumpDeprecation(resp)
+
 	if c.cfg.Debug {
 		dump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
@@ -764,4 +766,44 @@ func formatErrorMessage(status string, v interface{}) string {
 	}
 
 	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+}
+
+// dumpDeprecation logs headers defined by
+// https://tools.ietf.org/html/rfc8594
+// copied from https://github.com/packngo
+// for backwards compatibility
+func dumpDeprecation(resp *http.Response) {
+	uri := ""
+	if resp.Request != nil {
+		uri = resp.Request.Method + " " + resp.Request.URL.Path
+	}
+
+	deprecation := resp.Header.Get("Deprecation")
+	if deprecation != "" {
+		if deprecation == "true" {
+			deprecation = ""
+		} else {
+			deprecation = " on " + deprecation
+		}
+		log.Printf("WARNING: %q reported deprecation%s", uri, deprecation)
+	}
+
+	sunset := resp.Header.Get("Sunset")
+	if sunset != "" {
+		log.Printf("WARNING: %q reported sunsetting on %s", uri, sunset)
+	}
+
+	links := resp.Header.Values("Link")
+
+	for _, s := range links {
+		for _, ss := range strings.Split(s, ",") {
+			if strings.Contains(ss, "rel=\"sunset\"") {
+				link := strings.Split(ss, ";")[0]
+				log.Printf("WARNING: See %s for sunset details", link)
+			} else if strings.Contains(ss, "rel=\"deprecation\"") {
+				link := strings.Split(ss, ";")[0]
+				log.Printf("WARNING: See %s for deprecation details", link)
+			}
+		}
+	}
 }

--- a/patches/post/20230626-log-sunset-deprecation-headers.patch
+++ b/patches/post/20230626-log-sunset-deprecation-headers.patch
@@ -1,0 +1,57 @@
+diff --git a/metal/v1/client.go b/metal/v1/client.go
+index aa16a52..c1f0983 100644
+--- a/metal/v1/client.go
++++ b/metal/v1/client.go
+@@ -362,6 +362,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
+ 		return resp, err
+ 	}
+ 
++    dumpDeprecation(resp)
++
+ 	if c.cfg.Debug {
+ 		dump, err := httputil.DumpResponse(resp, true)
+ 		if err != nil {
+@@ -765,3 +767,43 @@ func formatErrorMessage(status string, v interface{}) string {
+ 
+ 	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+ }
++
++// dumpDeprecation logs headers defined by
++// https://tools.ietf.org/html/rfc8594
++// copied from https://github.com/packngo
++// for backwards compatibility
++func dumpDeprecation(resp *http.Response) {
++	uri := ""
++	if resp.Request != nil {
++		uri = resp.Request.Method + " " + resp.Request.URL.Path
++	}
++
++	deprecation := resp.Header.Get("Deprecation")
++	if deprecation != "" {
++		if deprecation == "true" {
++			deprecation = ""
++		} else {
++			deprecation = " on " + deprecation
++		}
++		log.Printf("WARNING: %q reported deprecation%s", uri, deprecation)
++	}
++
++	sunset := resp.Header.Get("Sunset")
++	if sunset != "" {
++		log.Printf("WARNING: %q reported sunsetting on %s", uri, sunset)
++	}
++
++	links := resp.Header.Values("Link")
++
++	for _, s := range links {
++		for _, ss := range strings.Split(s, ",") {
++			if strings.Contains(ss, "rel=\"sunset\"") {
++				link := strings.Split(ss, ";")[0]
++				log.Printf("WARNING: See %s for sunset details", link)
++			} else if strings.Contains(ss, "rel=\"deprecation\"") {
++				link := strings.Split(ss, ";")[0]
++				log.Printf("WARNING: See %s for deprecation details", link)
++			}
++		}
++	}
++}


### PR DESCRIPTION
To make it easier to adopt `metal-go` in place of `packngo`, this copies the `packngo` logic to dump sunset & deprecation headers to stdout.  The Equinix Metal API uses these headers to communicate important changes and there is long-standing precedent for dumping these headers to stdout in all of our Equinix Metal API integrations.