### PR TITLE
feat: add required field validation

### DIFF
--- a/metal/v1/model_address.go
+++ b/metal/v1/model_address.go
@@ -286,6 +286,22 @@ func (o Address) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Address) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"address",
+		"country",
+		"zip_code",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varAddress := _Address{}
 
 	err = json.Unmarshal(bytes, &varAddress)

--- a/metal/v1/model_bgp_config_request_input.go
+++ b/metal/v1/model_bgp_config_request_input.go
@@ -190,6 +190,21 @@ func (o BgpConfigRequestInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *BgpConfigRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"asn",
+		"deployment_type",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varBgpConfigRequestInput := _BgpConfigRequestInput{}
 
 	err = json.Unmarshal(bytes, &varBgpConfigRequestInput)

--- a/metal/v1/model_bgp_dynamic_neighbor_create_input.go
+++ b/metal/v1/model_bgp_dynamic_neighbor_create_input.go
@@ -153,6 +153,21 @@ func (o BgpDynamicNeighborCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *BgpDynamicNeighborCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"bgp_neighbor_range",
+		"bgp_neighbor_asn",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varBgpDynamicNeighborCreateInput := _BgpDynamicNeighborCreateInput{}
 
 	err = json.Unmarshal(bytes, &varBgpDynamicNeighborCreateInput)

--- a/metal/v1/model_bgp_session.go
+++ b/metal/v1/model_bgp_session.go
@@ -377,6 +377,20 @@ func (o BgpSession) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *BgpSession) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"address_family",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varBgpSession := _BgpSession{}
 
 	err = json.Unmarshal(bytes, &varBgpSession)

--- a/metal/v1/model_create_email_input.go
+++ b/metal/v1/model_create_email_input.go
@@ -88,6 +88,20 @@ func (o CreateEmailInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *CreateEmailInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"address",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varCreateEmailInput := _CreateEmailInput{}
 
 	err = json.Unmarshal(bytes, &varCreateEmailInput)

--- a/metal/v1/model_dedicated_port_create_input.go
+++ b/metal/v1/model_dedicated_port_create_input.go
@@ -463,6 +463,23 @@ func (o DedicatedPortCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DedicatedPortCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+		"name",
+		"redundancy",
+		"type",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDedicatedPortCreateInput := _DedicatedPortCreateInput{}
 
 	err = json.Unmarshal(bytes, &varDedicatedPortCreateInput)

--- a/metal/v1/model_device_action_input.go
+++ b/metal/v1/model_device_action_input.go
@@ -273,6 +273,20 @@ func (o DeviceActionInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DeviceActionInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"type",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDeviceActionInput := _DeviceActionInput{}
 
 	err = json.Unmarshal(bytes, &varDeviceActionInput)

--- a/metal/v1/model_device_create_in_facility_input.go
+++ b/metal/v1/model_device_create_in_facility_input.go
@@ -1022,6 +1022,22 @@ func (o DeviceCreateInFacilityInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DeviceCreateInFacilityInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"facility",
+		"operating_system",
+		"plan",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDeviceCreateInFacilityInput := _DeviceCreateInFacilityInput{}
 
 	err = json.Unmarshal(bytes, &varDeviceCreateInFacilityInput)

--- a/metal/v1/model_device_create_in_metro_input.go
+++ b/metal/v1/model_device_create_in_metro_input.go
@@ -1018,6 +1018,22 @@ func (o DeviceCreateInMetroInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DeviceCreateInMetroInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+		"operating_system",
+		"plan",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDeviceCreateInMetroInput := _DeviceCreateInMetroInput{}
 
 	err = json.Unmarshal(bytes, &varDeviceCreateInMetroInput)

--- a/metal/v1/model_device_create_input.go
+++ b/metal/v1/model_device_create_input.go
@@ -990,6 +990,21 @@ func (o DeviceCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DeviceCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"operating_system",
+		"plan",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDeviceCreateInput := _DeviceCreateInput{}
 
 	err = json.Unmarshal(bytes, &varDeviceCreateInput)

--- a/metal/v1/model_device_created_by.go
+++ b/metal/v1/model_device_created_by.go
@@ -414,6 +414,21 @@ func (o DeviceCreatedBy) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DeviceCreatedBy) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"id",
+		"short_id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDeviceCreatedBy := _DeviceCreatedBy{}
 
 	err = json.Unmarshal(bytes, &varDeviceCreatedBy)

--- a/metal/v1/model_device_project_lite.go
+++ b/metal/v1/model_device_project_lite.go
@@ -88,6 +88,20 @@ func (o DeviceProjectLite) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DeviceProjectLite) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"href",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varDeviceProjectLite := _DeviceProjectLite{}
 
 	err = json.Unmarshal(bytes, &varDeviceProjectLite)

--- a/metal/v1/model_email_input.go
+++ b/metal/v1/model_email_input.go
@@ -124,6 +124,20 @@ func (o EmailInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *EmailInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"address",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varEmailInput := _EmailInput{}
 
 	err = json.Unmarshal(bytes, &varEmailInput)

--- a/metal/v1/model_entitlement.go
+++ b/metal/v1/model_entitlement.go
@@ -470,6 +470,22 @@ func (o Entitlement) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Entitlement) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"id",
+		"slug",
+		"weight",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varEntitlement := _Entitlement{}
 
 	err = json.Unmarshal(bytes, &varEntitlement)

--- a/metal/v1/model_facility_input.go
+++ b/metal/v1/model_facility_input.go
@@ -93,6 +93,20 @@ func (o FacilityInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *FacilityInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"facility",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varFacilityInput := _FacilityInput{}
 
 	err = json.Unmarshal(bytes, &varFacilityInput)

--- a/metal/v1/model_find_traffic_timeframe_parameter.go
+++ b/metal/v1/model_find_traffic_timeframe_parameter.go
@@ -116,6 +116,21 @@ func (o FindTrafficTimeframeParameter) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *FindTrafficTimeframeParameter) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"ended_at",
+		"started_at",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varFindTrafficTimeframeParameter := _FindTrafficTimeframeParameter{}
 
 	err = json.Unmarshal(bytes, &varFindTrafficTimeframeParameter)

--- a/metal/v1/model_firmware_set.go
+++ b/metal/v1/model_firmware_set.go
@@ -266,6 +266,21 @@ func (o FirmwareSet) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *FirmwareSet) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"uuid",
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varFirmwareSet := _FirmwareSet{}
 
 	err = json.Unmarshal(bytes, &varFirmwareSet)

--- a/metal/v1/model_href.go
+++ b/metal/v1/model_href.go
@@ -88,6 +88,20 @@ func (o Href) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Href) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"href",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varHref := _Href{}
 
 	err = json.Unmarshal(bytes, &varHref)

--- a/metal/v1/model_instances_batch_create_input_batches_inner.go
+++ b/metal/v1/model_instances_batch_create_input_batches_inner.go
@@ -1123,6 +1123,23 @@ func (o InstancesBatchCreateInputBatchesInner) ToMap() (map[string]interface{}, 
 }
 
 func (o *InstancesBatchCreateInputBatchesInner) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+		"operating_system",
+		"plan",
+		"facility",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varInstancesBatchCreateInputBatchesInner := _InstancesBatchCreateInputBatchesInner{}
 
 	err = json.Unmarshal(bytes, &varInstancesBatchCreateInputBatchesInner)

--- a/metal/v1/model_invitation_input.go
+++ b/metal/v1/model_invitation_input.go
@@ -232,6 +232,20 @@ func (o InvitationInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *InvitationInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"invitee",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varInvitationInput := _InvitationInput{}
 
 	err = json.Unmarshal(bytes, &varInvitationInput)

--- a/metal/v1/model_ip_assignment_input.go
+++ b/metal/v1/model_ip_assignment_input.go
@@ -124,6 +124,20 @@ func (o IPAssignmentInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *IPAssignmentInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"address",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varIPAssignmentInput := _IPAssignmentInput{}
 
 	err = json.Unmarshal(bytes, &varIPAssignmentInput)

--- a/metal/v1/model_ip_reservation_request_input.go
+++ b/metal/v1/model_ip_reservation_request_input.go
@@ -368,6 +368,21 @@ func (o IPReservationRequestInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *IPReservationRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"quantity",
+		"type",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varIPReservationRequestInput := _IPReservationRequestInput{}
 
 	err = json.Unmarshal(bytes, &varIPReservationRequestInput)

--- a/metal/v1/model_metal_gateway_create_input.go
+++ b/metal/v1/model_metal_gateway_create_input.go
@@ -163,6 +163,20 @@ func (o MetalGatewayCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *MetalGatewayCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"virtual_network_id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varMetalGatewayCreateInput := _MetalGatewayCreateInput{}
 
 	err = json.Unmarshal(bytes, &varMetalGatewayCreateInput)

--- a/metal/v1/model_metal_gateway_elastic_ip_create_input.go
+++ b/metal/v1/model_metal_gateway_elastic_ip_create_input.go
@@ -191,6 +191,21 @@ func (o MetalGatewayElasticIpCreateInput) ToMap() (map[string]interface{}, error
 }
 
 func (o *MetalGatewayElasticIpCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"address",
+		"next_hop",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varMetalGatewayElasticIpCreateInput := _MetalGatewayElasticIpCreateInput{}
 
 	err = json.Unmarshal(bytes, &varMetalGatewayElasticIpCreateInput)

--- a/metal/v1/model_metro_input.go
+++ b/metal/v1/model_metro_input.go
@@ -89,6 +89,20 @@ func (o MetroInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *MetroInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varMetroInput := _MetroInput{}
 
 	err = json.Unmarshal(bytes, &varMetroInput)

--- a/metal/v1/model_payment_method_create_input.go
+++ b/metal/v1/model_payment_method_create_input.go
@@ -151,6 +151,21 @@ func (o PaymentMethodCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *PaymentMethodCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"name",
+		"nonce",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varPaymentMethodCreateInput := _PaymentMethodCreateInput{}
 
 	err = json.Unmarshal(bytes, &varPaymentMethodCreateInput)

--- a/metal/v1/model_project_create_from_root_input.go
+++ b/metal/v1/model_project_create_from_root_input.go
@@ -269,6 +269,20 @@ func (o ProjectCreateFromRootInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *ProjectCreateFromRootInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varProjectCreateFromRootInput := _ProjectCreateFromRootInput{}
 
 	err = json.Unmarshal(bytes, &varProjectCreateFromRootInput)

--- a/metal/v1/model_project_create_input.go
+++ b/metal/v1/model_project_create_input.go
@@ -233,6 +233,20 @@ func (o ProjectCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *ProjectCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varProjectCreateInput := _ProjectCreateInput{}
 
 	err = json.Unmarshal(bytes, &varProjectCreateInput)

--- a/metal/v1/model_support_request_input.go
+++ b/metal/v1/model_support_request_input.go
@@ -223,6 +223,21 @@ func (o SupportRequestInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *SupportRequestInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"message",
+		"subject",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varSupportRequestInput := _SupportRequestInput{}
 
 	err = json.Unmarshal(bytes, &varSupportRequestInput)

--- a/metal/v1/model_user_create_input.go
+++ b/metal/v1/model_user_create_input.go
@@ -648,6 +648,22 @@ func (o UserCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *UserCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"emails",
+		"first_name",
+		"last_name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varUserCreateInput := _UserCreateInput{}
 
 	err = json.Unmarshal(bytes, &varUserCreateInput)

--- a/metal/v1/model_user_limited.go
+++ b/metal/v1/model_user_limited.go
@@ -237,6 +237,20 @@ func (o UserLimited) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *UserLimited) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varUserLimited := _UserLimited{}
 
 	err = json.Unmarshal(bytes, &varUserLimited)

--- a/metal/v1/model_user_lite.go
+++ b/metal/v1/model_user_lite.go
@@ -414,6 +414,21 @@ func (o UserLite) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *UserLite) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"id",
+		"short_id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varUserLite := _UserLite{}
 
 	err = json.Unmarshal(bytes, &varUserLite)

--- a/metal/v1/model_verify_email.go
+++ b/metal/v1/model_verify_email.go
@@ -89,6 +89,20 @@ func (o VerifyEmail) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VerifyEmail) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"user_token",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVerifyEmail := _VerifyEmail{}
 
 	err = json.Unmarshal(bytes, &varVerifyEmail)

--- a/metal/v1/model_vlan_fabric_vc_create_input.go
+++ b/metal/v1/model_vlan_fabric_vc_create_input.go
@@ -417,6 +417,24 @@ func (o VlanFabricVcCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VlanFabricVcCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+		"name",
+		"redundancy",
+		"service_token_type",
+		"type",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVlanFabricVcCreateInput := _VlanFabricVcCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVlanFabricVcCreateInput)

--- a/metal/v1/model_vlan_virtual_circuit_create_input.go
+++ b/metal/v1/model_vlan_virtual_circuit_create_input.go
@@ -306,6 +306,20 @@ func (o VlanVirtualCircuitCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VlanVirtualCircuitCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"project_id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVlanVirtualCircuitCreateInput := _VlanVirtualCircuitCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVlanVirtualCircuitCreateInput)

--- a/metal/v1/model_vrf_create_input.go
+++ b/metal/v1/model_vrf_create_input.go
@@ -372,6 +372,21 @@ func (o VrfCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfCreateInput := _VrfCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVrfCreateInput)

--- a/metal/v1/model_vrf_fabric_vc_create_input.go
+++ b/metal/v1/model_vrf_fabric_vc_create_input.go
@@ -408,6 +408,25 @@ func (o VrfFabricVcCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfFabricVcCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"metro",
+		"name",
+		"redundancy",
+		"service_token_type",
+		"type",
+		"vrfs",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfFabricVcCreateInput := _VrfFabricVcCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVrfFabricVcCreateInput)

--- a/metal/v1/model_vrf_ip_reservation.go
+++ b/metal/v1/model_vrf_ip_reservation.go
@@ -908,6 +908,21 @@ func (o VrfIpReservation) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfIpReservation) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"type",
+		"vrf",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfIpReservation := _VrfIpReservation{}
 
 	err = json.Unmarshal(bytes, &varVrfIpReservation)

--- a/metal/v1/model_vrf_ip_reservation_create_input.go
+++ b/metal/v1/model_vrf_ip_reservation_create_input.go
@@ -281,6 +281,23 @@ func (o VrfIpReservationCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfIpReservationCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"cidr",
+		"network",
+		"type",
+		"vrf_id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfIpReservationCreateInput := _VrfIpReservationCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVrfIpReservationCreateInput)

--- a/metal/v1/model_vrf_metal_gateway_create_input.go
+++ b/metal/v1/model_vrf_metal_gateway_create_input.go
@@ -117,6 +117,21 @@ func (o VrfMetalGatewayCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfMetalGatewayCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"ip_reservation_id",
+		"virtual_network_id",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfMetalGatewayCreateInput := _VrfMetalGatewayCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVrfMetalGatewayCreateInput)

--- a/metal/v1/model_vrf_route_create_input.go
+++ b/metal/v1/model_vrf_route_create_input.go
@@ -153,6 +153,21 @@ func (o VrfRouteCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfRouteCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"prefix",
+		"next_hop",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfRouteCreateInput := _VrfRouteCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVrfRouteCreateInput)

--- a/metal/v1/model_vrf_virtual_circuit.go
+++ b/metal/v1/model_vrf_virtual_circuit.go
@@ -707,6 +707,20 @@ func (o VrfVirtualCircuit) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfVirtualCircuit) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"vrf",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfVirtualCircuit := _VrfVirtualCircuit{}
 
 	err = json.Unmarshal(bytes, &varVrfVirtualCircuit)

--- a/metal/v1/model_vrf_virtual_circuit_create_input.go
+++ b/metal/v1/model_vrf_virtual_circuit_create_input.go
@@ -466,6 +466,24 @@ func (o VrfVirtualCircuitCreateInput) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *VrfVirtualCircuitCreateInput) UnmarshalJSON(bytes []byte) (err error) {
+	requiredProperties := []string{
+		"nni_vlan",
+		"peer_asn",
+		"project_id",
+		"subnet",
+		"vrf",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range requiredProperties {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
 	varVrfVirtualCircuitCreateInput := _VrfVirtualCircuitCreateInput{}
 
 	err = json.Unmarshal(bytes, &varVrfVirtualCircuitCreateInput)

--- a/metal/v1/utils.go
+++ b/metal/v1/utils.go
@@ -13,6 +13,7 @@ package v1
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"time"
 )
@@ -345,4 +346,8 @@ func IsNil(i interface{}) bool {
 
 type MappedNullable interface {
 	ToMap() (map[string]interface{}, error)
+}
+
+func MissingRequiredFieldError(name string) error {
+	return fmt.Errorf("no value given for required field %v", name)
 }

--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -333,6 +333,24 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+{{#hasRequired}}
+	requiredProperties := []string{
+{{#requiredVars}}
+		"{{baseName}}",
+{{/requiredVars}}
+	}
+
+	allProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &allProperties); err == nil {
+		for _, requiredProperty := range(requiredProperties) {
+			if _, exists := allProperties[requiredProperty]; !exists {
+				return MissingRequiredFieldError(requiredProperty)
+			}
+		}
+	}
+
+{{/hasRequired}}
 {{#parent}}
 {{^isMap}}
 	type {{classname}}WithoutEmbeddedStruct struct {

--- a/templates/utils.mustache
+++ b/templates/utils.mustache
@@ -1,0 +1,343 @@
+{{>partial_header}}
+package {{packageName}}
+
+import (
+	"fmt"
+	"encoding/json"
+	"reflect"
+	"time"
+)
+
+// PtrBool is a helper routine that returns a pointer to given boolean value.
+func PtrBool(v bool) *bool { return &v }
+
+// PtrInt is a helper routine that returns a pointer to given integer value.
+func PtrInt(v int) *int { return &v }
+
+// PtrInt32 is a helper routine that returns a pointer to given integer value.
+func PtrInt32(v int32) *int32 { return &v }
+
+// PtrInt64 is a helper routine that returns a pointer to given integer value.
+func PtrInt64(v int64) *int64 { return &v }
+
+// PtrFloat32 is a helper routine that returns a pointer to given float value.
+func PtrFloat32(v float32) *float32 { return &v }
+
+// PtrFloat64 is a helper routine that returns a pointer to given float value.
+func PtrFloat64(v float64) *float64 { return &v }
+
+// PtrString is a helper routine that returns a pointer to given string value.
+func PtrString(v string) *string { return &v }
+
+// PtrTime is helper routine that returns a pointer to given Time value.
+func PtrTime(v time.Time) *time.Time { return &v }
+
+type NullableBool struct {
+	value *bool
+	isSet bool
+}
+
+func (v NullableBool) Get() *bool {
+	return v.value
+}
+
+func (v *NullableBool) Set(val *bool) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableBool) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableBool) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableBool(val *bool) *NullableBool {
+	return &NullableBool{value: val, isSet: true}
+}
+
+func (v NullableBool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableBool) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableInt struct {
+	value *int
+	isSet bool
+}
+
+func (v NullableInt) Get() *int {
+	return v.value
+}
+
+func (v *NullableInt) Set(val *int) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableInt) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableInt) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableInt(val *int) *NullableInt {
+	return &NullableInt{value: val, isSet: true}
+}
+
+func (v NullableInt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableInt) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableInt32 struct {
+	value *int32
+	isSet bool
+}
+
+func (v NullableInt32) Get() *int32 {
+	return v.value
+}
+
+func (v *NullableInt32) Set(val *int32) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableInt32) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableInt32) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableInt32(val *int32) *NullableInt32 {
+	return &NullableInt32{value: val, isSet: true}
+}
+
+func (v NullableInt32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableInt32) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableInt64 struct {
+	value *int64
+	isSet bool
+}
+
+func (v NullableInt64) Get() *int64 {
+	return v.value
+}
+
+func (v *NullableInt64) Set(val *int64) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableInt64) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableInt64) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableInt64(val *int64) *NullableInt64 {
+	return &NullableInt64{value: val, isSet: true}
+}
+
+func (v NullableInt64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableInt64) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableFloat32 struct {
+	value *float32
+	isSet bool
+}
+
+func (v NullableFloat32) Get() *float32 {
+	return v.value
+}
+
+func (v *NullableFloat32) Set(val *float32) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFloat32) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFloat32) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFloat32(val *float32) *NullableFloat32 {
+	return &NullableFloat32{value: val, isSet: true}
+}
+
+func (v NullableFloat32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableFloat64 struct {
+	value *float64
+	isSet bool
+}
+
+func (v NullableFloat64) Get() *float64 {
+	return v.value
+}
+
+func (v *NullableFloat64) Set(val *float64) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFloat64) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFloat64) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFloat64(val *float64) *NullableFloat64 {
+	return &NullableFloat64{value: val, isSet: true}
+}
+
+func (v NullableFloat64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableString struct {
+	value *string
+	isSet bool
+}
+
+func (v NullableString) Get() *string {
+	return v.value
+}
+
+func (v *NullableString) Set(val *string) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableString) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableString) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableString(val *string) *NullableString {
+	return &NullableString{value: val, isSet: true}
+}
+
+func (v NullableString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableString) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableTime struct {
+	value *time.Time
+	isSet bool
+}
+
+func (v NullableTime) Get() *time.Time {
+	return v.value
+}
+
+func (v *NullableTime) Set(val *time.Time) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableTime) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableTime) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableTime(val *time.Time) *NullableTime {
+	return &NullableTime{value: val, isSet: true}
+}
+
+func (v NullableTime) MarshalJSON() ([]byte, error) {
+	return v.value.MarshalJSON()
+}
+
+func (v *NullableTime) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+// IsNil checks if an input is nil
+func IsNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return reflect.ValueOf(i).IsNil()
+	case reflect.Array:
+		return reflect.ValueOf(i).IsZero()
+	}
+	return false
+}
+
+type MappedNullable interface {
+	ToMap() (map[string]interface{}, error)
+}
+
+func MissingRequiredFieldError(name string) error {
+	return fmt.Errorf("no value given for required field %v", name)
+}


### PR DESCRIPTION
This adds required field validation analogous to the required field validation that exists in the Java generator (TODO: link to example in metal-java).

Required fields are validated by:
1. Creating a list of required property names
2. Unmarshalling the current object into a map with string keys
3. Validating that required property names appear as keys in the unmarshalled map

Templates are updated here: b5c00de1d6749f0b82bd8623d72b817c077099a9
Code is regenerated here: 3e16fd3516bd1ec717e7611179fd77d550eeaf63