### PR TITLE
fix: updated propert quantity in metro info

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -15038,7 +15038,7 @@ components:
       type: object
     CapacityCheckPerMetroInfo:
       example:
-        quantity: 0
+        quantity: quantity
         metro: metro
         available: true
         plan: plan
@@ -15055,16 +15055,16 @@ components:
           type: string
         quantity:
           description: The number of servers sent to check capacity.
-          type: integer
+          type: string
       type: object
     CapacityCheckPerMetroList:
       example:
         servers:
-        - quantity: 0
+        - quantity: quantity
           metro: metro
           available: true
           plan: plan
-        - quantity: 0
+        - quantity: quantity
           metro: metro
           available: true
           plan: plan

--- a/docs/CapacityCheckPerMetroInfo.md
+++ b/docs/CapacityCheckPerMetroInfo.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Available** | Pointer to **bool** | Returns true if there is enough capacity in the metro to fulfill the quantity set. Returns false if there is not enough. | [optional] 
 **Metro** | Pointer to **string** | The metro ID or code sent to check capacity. | [optional] 
 **Plan** | Pointer to **string** | The plan ID or slug sent to check capacity. | [optional] 
-**Quantity** | Pointer to **int32** | The number of servers sent to check capacity. | [optional] 
+**Quantity** | Pointer to **string** | The number of servers sent to check capacity. | [optional] 
 
 ## Methods
 
@@ -105,20 +105,20 @@ HasPlan returns a boolean if a field has been set.
 
 ### GetQuantity
 
-`func (o *CapacityCheckPerMetroInfo) GetQuantity() int32`
+`func (o *CapacityCheckPerMetroInfo) GetQuantity() string`
 
 GetQuantity returns the Quantity field if non-nil, zero value otherwise.
 
 ### GetQuantityOk
 
-`func (o *CapacityCheckPerMetroInfo) GetQuantityOk() (*int32, bool)`
+`func (o *CapacityCheckPerMetroInfo) GetQuantityOk() (*string, bool)`
 
 GetQuantityOk returns a tuple with the Quantity field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetQuantity
 
-`func (o *CapacityCheckPerMetroInfo) SetQuantity(v int32)`
+`func (o *CapacityCheckPerMetroInfo) SetQuantity(v string)`
 
 SetQuantity sets Quantity field to given value.
 

--- a/metal/v1/model_capacity_check_per_metro_info.go
+++ b/metal/v1/model_capacity_check_per_metro_info.go
@@ -27,7 +27,7 @@ type CapacityCheckPerMetroInfo struct {
 	// The plan ID or slug sent to check capacity.
 	Plan *string `json:"plan,omitempty"`
 	// The number of servers sent to check capacity.
-	Quantity             *int32 `json:"quantity,omitempty"`
+	Quantity             *string `json:"quantity,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -147,9 +147,9 @@ func (o *CapacityCheckPerMetroInfo) SetPlan(v string) {
 }
 
 // GetQuantity returns the Quantity field value if set, zero value otherwise.
-func (o *CapacityCheckPerMetroInfo) GetQuantity() int32 {
+func (o *CapacityCheckPerMetroInfo) GetQuantity() string {
 	if o == nil || IsNil(o.Quantity) {
-		var ret int32
+		var ret string
 		return ret
 	}
 	return *o.Quantity
@@ -157,7 +157,7 @@ func (o *CapacityCheckPerMetroInfo) GetQuantity() int32 {
 
 // GetQuantityOk returns a tuple with the Quantity field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *CapacityCheckPerMetroInfo) GetQuantityOk() (*int32, bool) {
+func (o *CapacityCheckPerMetroInfo) GetQuantityOk() (*string, bool) {
 	if o == nil || IsNil(o.Quantity) {
 		return nil, false
 	}
@@ -173,8 +173,8 @@ func (o *CapacityCheckPerMetroInfo) HasQuantity() bool {
 	return false
 }
 
-// SetQuantity gets a reference to the given int32 and assigns it to the Quantity field.
-func (o *CapacityCheckPerMetroInfo) SetQuantity(v int32) {
+// SetQuantity gets a reference to the given string and assigns it to the Quantity field.
+func (o *CapacityCheckPerMetroInfo) SetQuantity(v string) {
 	o.Quantity = &v
 }
 

--- a/patches/spec.fetched.json/20230908-updated-pro-quantity-in-metro-info.patch
+++ b/patches/spec.fetched.json/20230908-updated-pro-quantity-in-metro-info.patch
@@ -1,0 +1,11 @@
+diff --git a/spec/oas3.patched/components/schemas/CapacityCheckPerMetroInfo.yaml b/spec/oas3.patched/components/schemas/CapacityCheckPerMetroInfo.yaml
+index de2afda..2fb51ba 100644
+--- a/spec/oas3.patched/components/schemas/CapacityCheckPerMetroInfo.yaml
++++ b/spec/oas3.patched/components/schemas/CapacityCheckPerMetroInfo.yaml
+@@ -11,5 +11,5 @@ properties:
+     type: string
+   quantity:
+     description: The number of servers sent to check capacity.
+-    type: integer
++    type: string
+ type: object

--- a/spec/oas3.patched/components/schemas/CapacityCheckPerMetroInfo.yaml
+++ b/spec/oas3.patched/components/schemas/CapacityCheckPerMetroInfo.yaml
@@ -11,5 +11,5 @@ properties:
     type: string
   quantity:
     description: The number of servers sent to check capacity.
-    type: integer
+    type: string
 type: object


### PR DESCRIPTION
## Description:

The quantity filed type is changed from string to int32 (v0.17.0 - v0.19.0). But it returns zero in all cases.
In this PR we reverted the type from the int string back.

## What issues it Fix?

https://github.com/equinix-labs/metal-go/issues/142