### PR TITLE
chore: create a wrapper task for SDK generation

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,7 +42,7 @@ jobs:
       id: generate
       if: ${{ always() && steps.patch.conclusion == 'success' }}
       run: |
-        make clean gen mod docs move-other patch-post fmt test
+        make generate
         git add api docs metal API.md go.mod go.sum
         echo `git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec'`
     - name: Create Pull Request

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
       run: make patch
     - name: Generate
       run: |
-        make clean gen mod docs move-other patch-post fmt test
+        make generate
         # Expect all changes to be accounted for
         ! git status --porcelain | grep .

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,7 +27,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "echo -n '${nextRelease.version}' > version && make clean gen mod docs move-other patch-post fmt"
+          "prepareCmd": "echo -n '${nextRelease.version}' > version && make generate"
         }
       ],
       [

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all gen patch fetch
+.PHONY: all pull fetch patch generate clean codegen mod docs move-other patch-post fmt test stage
 
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
@@ -24,7 +24,9 @@ OPENAPI_GENERATOR=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):
 SPEC_FETCHER=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 GOLANGCI_LINT=golangci-lint
 
-all: pull fetch patch clean gen mod docs move-other patch-post fmt test stage
+all: pull fetch patch generate stage
+
+generate: clean codegen mod docs move-other patch-post fmt test
 
 pull:
 	${CRI} pull ${OPENAPI_IMAGE}
@@ -49,7 +51,7 @@ patch-post:
 clean:
 	rm -rf $(PACKAGE_PREFIX)
 
-gen:
+codegen:
 	${OPENAPI_GENERATOR} generate -g go \
 		--package-name ${PACKAGE_MAJOR} \
 		--http-user-agent "${GIT_REPO}/${PACKAGE_VERSION}" \


### PR DESCRIPTION
We have the same sequence of Make tasks (`clean gen mod ...`) duplicated in a lot of places, which makes it hard to keep our CI workflows up-to-date and hard to know what tasks to run for local development.

This creates a `generate` wrapper task that encapsulates the various code generation steps that we previously ran as separate tasks:
- Code generation
- Moving documentation
- Formatting code

By creating & using this wrapper task, we make it easier to add or remove steps from the SDK generation process without having to update CI.