### PR TITLE
fix: return errors when JSON responses contain fields of wrong type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ codegen:
 		-p disallowAdditionalPropertiesIfNotPresent=false \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO}/${PACKAGE_PREFIX} \
+		-t /local/templates \
 		-o /local/${PACKAGE_PREFIX}/${PACKAGE_MAJOR} \
 		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 

--- a/metal/v1/model_activate_hardware_reservation_request.go
+++ b/metal/v1/model_activate_hardware_reservation_request.go
@@ -99,9 +99,13 @@ func (o ActivateHardwareReservationRequest) ToMap() (map[string]interface{}, err
 func (o *ActivateHardwareReservationRequest) UnmarshalJSON(bytes []byte) (err error) {
 	varActivateHardwareReservationRequest := _ActivateHardwareReservationRequest{}
 
-	if err = json.Unmarshal(bytes, &varActivateHardwareReservationRequest); err == nil {
-		*o = ActivateHardwareReservationRequest(varActivateHardwareReservationRequest)
+	err = json.Unmarshal(bytes, &varActivateHardwareReservationRequest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ActivateHardwareReservationRequest(varActivateHardwareReservationRequest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_address.go
+++ b/metal/v1/model_address.go
@@ -288,9 +288,13 @@ func (o Address) ToMap() (map[string]interface{}, error) {
 func (o *Address) UnmarshalJSON(bytes []byte) (err error) {
 	varAddress := _Address{}
 
-	if err = json.Unmarshal(bytes, &varAddress); err == nil {
-		*o = Address(varAddress)
+	err = json.Unmarshal(bytes, &varAddress)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Address(varAddress)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_auth_token.go
+++ b/metal/v1/model_auth_token.go
@@ -353,9 +353,13 @@ func (o AuthToken) ToMap() (map[string]interface{}, error) {
 func (o *AuthToken) UnmarshalJSON(bytes []byte) (err error) {
 	varAuthToken := _AuthToken{}
 
-	if err = json.Unmarshal(bytes, &varAuthToken); err == nil {
-		*o = AuthToken(varAuthToken)
+	err = json.Unmarshal(bytes, &varAuthToken)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AuthToken(varAuthToken)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_auth_token_input.go
+++ b/metal/v1/model_auth_token_input.go
@@ -135,9 +135,13 @@ func (o AuthTokenInput) ToMap() (map[string]interface{}, error) {
 func (o *AuthTokenInput) UnmarshalJSON(bytes []byte) (err error) {
 	varAuthTokenInput := _AuthTokenInput{}
 
-	if err = json.Unmarshal(bytes, &varAuthTokenInput); err == nil {
-		*o = AuthTokenInput(varAuthTokenInput)
+	err = json.Unmarshal(bytes, &varAuthTokenInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AuthTokenInput(varAuthTokenInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_auth_token_list.go
+++ b/metal/v1/model_auth_token_list.go
@@ -99,9 +99,13 @@ func (o AuthTokenList) ToMap() (map[string]interface{}, error) {
 func (o *AuthTokenList) UnmarshalJSON(bytes []byte) (err error) {
 	varAuthTokenList := _AuthTokenList{}
 
-	if err = json.Unmarshal(bytes, &varAuthTokenList); err == nil {
-		*o = AuthTokenList(varAuthTokenList)
+	err = json.Unmarshal(bytes, &varAuthTokenList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AuthTokenList(varAuthTokenList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_auth_token_project.go
+++ b/metal/v1/model_auth_token_project.go
@@ -713,9 +713,13 @@ func (o AuthTokenProject) ToMap() (map[string]interface{}, error) {
 func (o *AuthTokenProject) UnmarshalJSON(bytes []byte) (err error) {
 	varAuthTokenProject := _AuthTokenProject{}
 
-	if err = json.Unmarshal(bytes, &varAuthTokenProject); err == nil {
-		*o = AuthTokenProject(varAuthTokenProject)
+	err = json.Unmarshal(bytes, &varAuthTokenProject)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AuthTokenProject(varAuthTokenProject)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_auth_token_user.go
+++ b/metal/v1/model_auth_token_user.go
@@ -856,9 +856,13 @@ func (o AuthTokenUser) ToMap() (map[string]interface{}, error) {
 func (o *AuthTokenUser) UnmarshalJSON(bytes []byte) (err error) {
 	varAuthTokenUser := _AuthTokenUser{}
 
-	if err = json.Unmarshal(bytes, &varAuthTokenUser); err == nil {
-		*o = AuthTokenUser(varAuthTokenUser)
+	err = json.Unmarshal(bytes, &varAuthTokenUser)
+
+	if err != nil {
+		return err
 	}
+
+	*o = AuthTokenUser(varAuthTokenUser)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_batch.go
+++ b/metal/v1/model_batch.go
@@ -352,9 +352,13 @@ func (o Batch) ToMap() (map[string]interface{}, error) {
 func (o *Batch) UnmarshalJSON(bytes []byte) (err error) {
 	varBatch := _Batch{}
 
-	if err = json.Unmarshal(bytes, &varBatch); err == nil {
-		*o = Batch(varBatch)
+	err = json.Unmarshal(bytes, &varBatch)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Batch(varBatch)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_batches_list.go
+++ b/metal/v1/model_batches_list.go
@@ -99,9 +99,13 @@ func (o BatchesList) ToMap() (map[string]interface{}, error) {
 func (o *BatchesList) UnmarshalJSON(bytes []byte) (err error) {
 	varBatchesList := _BatchesList{}
 
-	if err = json.Unmarshal(bytes, &varBatchesList); err == nil {
-		*o = BatchesList(varBatchesList)
+	err = json.Unmarshal(bytes, &varBatchesList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BatchesList(varBatchesList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_config.go
+++ b/metal/v1/model_bgp_config.go
@@ -555,9 +555,13 @@ func (o BgpConfig) ToMap() (map[string]interface{}, error) {
 func (o *BgpConfig) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpConfig := _BgpConfig{}
 
-	if err = json.Unmarshal(bytes, &varBgpConfig); err == nil {
-		*o = BgpConfig(varBgpConfig)
+	err = json.Unmarshal(bytes, &varBgpConfig)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpConfig(varBgpConfig)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_config_request_input.go
+++ b/metal/v1/model_bgp_config_request_input.go
@@ -193,9 +193,13 @@ func (o BgpConfigRequestInput) ToMap() (map[string]interface{}, error) {
 func (o *BgpConfigRequestInput) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpConfigRequestInput := _BgpConfigRequestInput{}
 
-	if err = json.Unmarshal(bytes, &varBgpConfigRequestInput); err == nil {
-		*o = BgpConfigRequestInput(varBgpConfigRequestInput)
+	err = json.Unmarshal(bytes, &varBgpConfigRequestInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpConfigRequestInput(varBgpConfigRequestInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_dynamic_neighbor.go
+++ b/metal/v1/model_bgp_dynamic_neighbor.go
@@ -427,9 +427,13 @@ func (o BgpDynamicNeighbor) ToMap() (map[string]interface{}, error) {
 func (o *BgpDynamicNeighbor) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpDynamicNeighbor := _BgpDynamicNeighbor{}
 
-	if err = json.Unmarshal(bytes, &varBgpDynamicNeighbor); err == nil {
-		*o = BgpDynamicNeighbor(varBgpDynamicNeighbor)
+	err = json.Unmarshal(bytes, &varBgpDynamicNeighbor)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpDynamicNeighbor(varBgpDynamicNeighbor)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_dynamic_neighbor_create_input.go
+++ b/metal/v1/model_bgp_dynamic_neighbor_create_input.go
@@ -155,9 +155,13 @@ func (o BgpDynamicNeighborCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *BgpDynamicNeighborCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpDynamicNeighborCreateInput := _BgpDynamicNeighborCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varBgpDynamicNeighborCreateInput); err == nil {
-		*o = BgpDynamicNeighborCreateInput(varBgpDynamicNeighborCreateInput)
+	err = json.Unmarshal(bytes, &varBgpDynamicNeighborCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpDynamicNeighborCreateInput(varBgpDynamicNeighborCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_dynamic_neighbor_list.go
+++ b/metal/v1/model_bgp_dynamic_neighbor_list.go
@@ -135,9 +135,13 @@ func (o BgpDynamicNeighborList) ToMap() (map[string]interface{}, error) {
 func (o *BgpDynamicNeighborList) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpDynamicNeighborList := _BgpDynamicNeighborList{}
 
-	if err = json.Unmarshal(bytes, &varBgpDynamicNeighborList); err == nil {
-		*o = BgpDynamicNeighborList(varBgpDynamicNeighborList)
+	err = json.Unmarshal(bytes, &varBgpDynamicNeighborList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpDynamicNeighborList(varBgpDynamicNeighborList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_neighbor_data.go
+++ b/metal/v1/model_bgp_neighbor_data.go
@@ -433,9 +433,13 @@ func (o BgpNeighborData) ToMap() (map[string]interface{}, error) {
 func (o *BgpNeighborData) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpNeighborData := _BgpNeighborData{}
 
-	if err = json.Unmarshal(bytes, &varBgpNeighborData); err == nil {
-		*o = BgpNeighborData(varBgpNeighborData)
+	err = json.Unmarshal(bytes, &varBgpNeighborData)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpNeighborData(varBgpNeighborData)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_route.go
+++ b/metal/v1/model_bgp_route.go
@@ -135,9 +135,13 @@ func (o BgpRoute) ToMap() (map[string]interface{}, error) {
 func (o *BgpRoute) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpRoute := _BgpRoute{}
 
-	if err = json.Unmarshal(bytes, &varBgpRoute); err == nil {
-		*o = BgpRoute(varBgpRoute)
+	err = json.Unmarshal(bytes, &varBgpRoute)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpRoute(varBgpRoute)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_session.go
+++ b/metal/v1/model_bgp_session.go
@@ -380,9 +380,13 @@ func (o BgpSession) ToMap() (map[string]interface{}, error) {
 func (o *BgpSession) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpSession := _BgpSession{}
 
-	if err = json.Unmarshal(bytes, &varBgpSession); err == nil {
-		*o = BgpSession(varBgpSession)
+	err = json.Unmarshal(bytes, &varBgpSession)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpSession(varBgpSession)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_session_input.go
+++ b/metal/v1/model_bgp_session_input.go
@@ -141,9 +141,13 @@ func (o BGPSessionInput) ToMap() (map[string]interface{}, error) {
 func (o *BGPSessionInput) UnmarshalJSON(bytes []byte) (err error) {
 	varBGPSessionInput := _BGPSessionInput{}
 
-	if err = json.Unmarshal(bytes, &varBGPSessionInput); err == nil {
-		*o = BGPSessionInput(varBGPSessionInput)
+	err = json.Unmarshal(bytes, &varBGPSessionInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BGPSessionInput(varBGPSessionInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_session_list.go
+++ b/metal/v1/model_bgp_session_list.go
@@ -99,9 +99,13 @@ func (o BgpSessionList) ToMap() (map[string]interface{}, error) {
 func (o *BgpSessionList) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpSessionList := _BgpSessionList{}
 
-	if err = json.Unmarshal(bytes, &varBgpSessionList); err == nil {
-		*o = BgpSessionList(varBgpSessionList)
+	err = json.Unmarshal(bytes, &varBgpSessionList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpSessionList(varBgpSessionList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bgp_session_neighbors.go
+++ b/metal/v1/model_bgp_session_neighbors.go
@@ -100,9 +100,13 @@ func (o BgpSessionNeighbors) ToMap() (map[string]interface{}, error) {
 func (o *BgpSessionNeighbors) UnmarshalJSON(bytes []byte) (err error) {
 	varBgpSessionNeighbors := _BgpSessionNeighbors{}
 
-	if err = json.Unmarshal(bytes, &varBgpSessionNeighbors); err == nil {
-		*o = BgpSessionNeighbors(varBgpSessionNeighbors)
+	err = json.Unmarshal(bytes, &varBgpSessionNeighbors)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BgpSessionNeighbors(varBgpSessionNeighbors)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_bond_port_data.go
+++ b/metal/v1/model_bond_port_data.go
@@ -137,9 +137,13 @@ func (o BondPortData) ToMap() (map[string]interface{}, error) {
 func (o *BondPortData) UnmarshalJSON(bytes []byte) (err error) {
 	varBondPortData := _BondPortData{}
 
-	if err = json.Unmarshal(bytes, &varBondPortData); err == nil {
-		*o = BondPortData(varBondPortData)
+	err = json.Unmarshal(bytes, &varBondPortData)
+
+	if err != nil {
+		return err
 	}
+
+	*o = BondPortData(varBondPortData)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_check_per_facility_info.go
+++ b/metal/v1/model_capacity_check_per_facility_info.go
@@ -207,9 +207,13 @@ func (o CapacityCheckPerFacilityInfo) ToMap() (map[string]interface{}, error) {
 func (o *CapacityCheckPerFacilityInfo) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityCheckPerFacilityInfo := _CapacityCheckPerFacilityInfo{}
 
-	if err = json.Unmarshal(bytes, &varCapacityCheckPerFacilityInfo); err == nil {
-		*o = CapacityCheckPerFacilityInfo(varCapacityCheckPerFacilityInfo)
+	err = json.Unmarshal(bytes, &varCapacityCheckPerFacilityInfo)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityCheckPerFacilityInfo(varCapacityCheckPerFacilityInfo)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_check_per_facility_list.go
+++ b/metal/v1/model_capacity_check_per_facility_list.go
@@ -99,9 +99,13 @@ func (o CapacityCheckPerFacilityList) ToMap() (map[string]interface{}, error) {
 func (o *CapacityCheckPerFacilityList) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityCheckPerFacilityList := _CapacityCheckPerFacilityList{}
 
-	if err = json.Unmarshal(bytes, &varCapacityCheckPerFacilityList); err == nil {
-		*o = CapacityCheckPerFacilityList(varCapacityCheckPerFacilityList)
+	err = json.Unmarshal(bytes, &varCapacityCheckPerFacilityList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityCheckPerFacilityList(varCapacityCheckPerFacilityList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_check_per_metro_info.go
+++ b/metal/v1/model_capacity_check_per_metro_info.go
@@ -211,9 +211,13 @@ func (o CapacityCheckPerMetroInfo) ToMap() (map[string]interface{}, error) {
 func (o *CapacityCheckPerMetroInfo) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityCheckPerMetroInfo := _CapacityCheckPerMetroInfo{}
 
-	if err = json.Unmarshal(bytes, &varCapacityCheckPerMetroInfo); err == nil {
-		*o = CapacityCheckPerMetroInfo(varCapacityCheckPerMetroInfo)
+	err = json.Unmarshal(bytes, &varCapacityCheckPerMetroInfo)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityCheckPerMetroInfo(varCapacityCheckPerMetroInfo)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_check_per_metro_list.go
+++ b/metal/v1/model_capacity_check_per_metro_list.go
@@ -99,9 +99,13 @@ func (o CapacityCheckPerMetroList) ToMap() (map[string]interface{}, error) {
 func (o *CapacityCheckPerMetroList) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityCheckPerMetroList := _CapacityCheckPerMetroList{}
 
-	if err = json.Unmarshal(bytes, &varCapacityCheckPerMetroList); err == nil {
-		*o = CapacityCheckPerMetroList(varCapacityCheckPerMetroList)
+	err = json.Unmarshal(bytes, &varCapacityCheckPerMetroList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityCheckPerMetroList(varCapacityCheckPerMetroList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_input.go
+++ b/metal/v1/model_capacity_input.go
@@ -99,9 +99,13 @@ func (o CapacityInput) ToMap() (map[string]interface{}, error) {
 func (o *CapacityInput) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityInput := _CapacityInput{}
 
-	if err = json.Unmarshal(bytes, &varCapacityInput); err == nil {
-		*o = CapacityInput(varCapacityInput)
+	err = json.Unmarshal(bytes, &varCapacityInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityInput(varCapacityInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_level_per_baremetal.go
+++ b/metal/v1/model_capacity_level_per_baremetal.go
@@ -99,9 +99,13 @@ func (o CapacityLevelPerBaremetal) ToMap() (map[string]interface{}, error) {
 func (o *CapacityLevelPerBaremetal) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityLevelPerBaremetal := _CapacityLevelPerBaremetal{}
 
-	if err = json.Unmarshal(bytes, &varCapacityLevelPerBaremetal); err == nil {
-		*o = CapacityLevelPerBaremetal(varCapacityLevelPerBaremetal)
+	err = json.Unmarshal(bytes, &varCapacityLevelPerBaremetal)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityLevelPerBaremetal(varCapacityLevelPerBaremetal)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_capacity_list.go
+++ b/metal/v1/model_capacity_list.go
@@ -99,9 +99,13 @@ func (o CapacityList) ToMap() (map[string]interface{}, error) {
 func (o *CapacityList) UnmarshalJSON(bytes []byte) (err error) {
 	varCapacityList := _CapacityList{}
 
-	if err = json.Unmarshal(bytes, &varCapacityList); err == nil {
-		*o = CapacityList(varCapacityList)
+	err = json.Unmarshal(bytes, &varCapacityList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CapacityList(varCapacityList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_coordinates.go
+++ b/metal/v1/model_coordinates.go
@@ -135,9 +135,13 @@ func (o Coordinates) ToMap() (map[string]interface{}, error) {
 func (o *Coordinates) UnmarshalJSON(bytes []byte) (err error) {
 	varCoordinates := _Coordinates{}
 
-	if err = json.Unmarshal(bytes, &varCoordinates); err == nil {
-		*o = Coordinates(varCoordinates)
+	err = json.Unmarshal(bytes, &varCoordinates)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Coordinates(varCoordinates)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_create_email_input.go
+++ b/metal/v1/model_create_email_input.go
@@ -90,9 +90,13 @@ func (o CreateEmailInput) ToMap() (map[string]interface{}, error) {
 func (o *CreateEmailInput) UnmarshalJSON(bytes []byte) (err error) {
 	varCreateEmailInput := _CreateEmailInput{}
 
-	if err = json.Unmarshal(bytes, &varCreateEmailInput); err == nil {
-		*o = CreateEmailInput(varCreateEmailInput)
+	err = json.Unmarshal(bytes, &varCreateEmailInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CreateEmailInput(varCreateEmailInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_create_self_service_reservation_request.go
+++ b/metal/v1/model_create_self_service_reservation_request.go
@@ -208,9 +208,13 @@ func (o CreateSelfServiceReservationRequest) ToMap() (map[string]interface{}, er
 func (o *CreateSelfServiceReservationRequest) UnmarshalJSON(bytes []byte) (err error) {
 	varCreateSelfServiceReservationRequest := _CreateSelfServiceReservationRequest{}
 
-	if err = json.Unmarshal(bytes, &varCreateSelfServiceReservationRequest); err == nil {
-		*o = CreateSelfServiceReservationRequest(varCreateSelfServiceReservationRequest)
+	err = json.Unmarshal(bytes, &varCreateSelfServiceReservationRequest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CreateSelfServiceReservationRequest(varCreateSelfServiceReservationRequest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_create_self_service_reservation_request_period.go
+++ b/metal/v1/model_create_self_service_reservation_request_period.go
@@ -135,9 +135,13 @@ func (o CreateSelfServiceReservationRequestPeriod) ToMap() (map[string]interface
 func (o *CreateSelfServiceReservationRequestPeriod) UnmarshalJSON(bytes []byte) (err error) {
 	varCreateSelfServiceReservationRequestPeriod := _CreateSelfServiceReservationRequestPeriod{}
 
-	if err = json.Unmarshal(bytes, &varCreateSelfServiceReservationRequestPeriod); err == nil {
-		*o = CreateSelfServiceReservationRequestPeriod(varCreateSelfServiceReservationRequestPeriod)
+	err = json.Unmarshal(bytes, &varCreateSelfServiceReservationRequestPeriod)
+
+	if err != nil {
+		return err
 	}
+
+	*o = CreateSelfServiceReservationRequestPeriod(varCreateSelfServiceReservationRequestPeriod)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_dedicated_port_create_input.go
+++ b/metal/v1/model_dedicated_port_create_input.go
@@ -467,9 +467,13 @@ func (o DedicatedPortCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *DedicatedPortCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varDedicatedPortCreateInput := _DedicatedPortCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varDedicatedPortCreateInput); err == nil {
-		*o = DedicatedPortCreateInput(varDedicatedPortCreateInput)
+	err = json.Unmarshal(bytes, &varDedicatedPortCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DedicatedPortCreateInput(varDedicatedPortCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device.go
+++ b/metal/v1/model_device.go
@@ -1588,9 +1588,13 @@ func (o Device) ToMap() (map[string]interface{}, error) {
 func (o *Device) UnmarshalJSON(bytes []byte) (err error) {
 	varDevice := _Device{}
 
-	if err = json.Unmarshal(bytes, &varDevice); err == nil {
-		*o = Device(varDevice)
+	err = json.Unmarshal(bytes, &varDevice)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Device(varDevice)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_action_input.go
+++ b/metal/v1/model_device_action_input.go
@@ -276,9 +276,13 @@ func (o DeviceActionInput) ToMap() (map[string]interface{}, error) {
 func (o *DeviceActionInput) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceActionInput := _DeviceActionInput{}
 
-	if err = json.Unmarshal(bytes, &varDeviceActionInput); err == nil {
-		*o = DeviceActionInput(varDeviceActionInput)
+	err = json.Unmarshal(bytes, &varDeviceActionInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceActionInput(varDeviceActionInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_actions_inner.go
+++ b/metal/v1/model_device_actions_inner.go
@@ -135,9 +135,13 @@ func (o DeviceActionsInner) ToMap() (map[string]interface{}, error) {
 func (o *DeviceActionsInner) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceActionsInner := _DeviceActionsInner{}
 
-	if err = json.Unmarshal(bytes, &varDeviceActionsInner); err == nil {
-		*o = DeviceActionsInner(varDeviceActionsInner)
+	err = json.Unmarshal(bytes, &varDeviceActionsInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceActionsInner(varDeviceActionsInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_create_in_facility_input.go
+++ b/metal/v1/model_device_create_in_facility_input.go
@@ -1025,9 +1025,13 @@ func (o DeviceCreateInFacilityInput) ToMap() (map[string]interface{}, error) {
 func (o *DeviceCreateInFacilityInput) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceCreateInFacilityInput := _DeviceCreateInFacilityInput{}
 
-	if err = json.Unmarshal(bytes, &varDeviceCreateInFacilityInput); err == nil {
-		*o = DeviceCreateInFacilityInput(varDeviceCreateInFacilityInput)
+	err = json.Unmarshal(bytes, &varDeviceCreateInFacilityInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceCreateInFacilityInput(varDeviceCreateInFacilityInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_create_in_metro_input.go
+++ b/metal/v1/model_device_create_in_metro_input.go
@@ -1021,9 +1021,13 @@ func (o DeviceCreateInMetroInput) ToMap() (map[string]interface{}, error) {
 func (o *DeviceCreateInMetroInput) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceCreateInMetroInput := _DeviceCreateInMetroInput{}
 
-	if err = json.Unmarshal(bytes, &varDeviceCreateInMetroInput); err == nil {
-		*o = DeviceCreateInMetroInput(varDeviceCreateInMetroInput)
+	err = json.Unmarshal(bytes, &varDeviceCreateInMetroInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceCreateInMetroInput(varDeviceCreateInMetroInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_create_input.go
+++ b/metal/v1/model_device_create_input.go
@@ -993,9 +993,13 @@ func (o DeviceCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *DeviceCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceCreateInput := _DeviceCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varDeviceCreateInput); err == nil {
-		*o = DeviceCreateInput(varDeviceCreateInput)
+	err = json.Unmarshal(bytes, &varDeviceCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceCreateInput(varDeviceCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_created_by.go
+++ b/metal/v1/model_device_created_by.go
@@ -416,9 +416,13 @@ func (o DeviceCreatedBy) ToMap() (map[string]interface{}, error) {
 func (o *DeviceCreatedBy) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceCreatedBy := _DeviceCreatedBy{}
 
-	if err = json.Unmarshal(bytes, &varDeviceCreatedBy); err == nil {
-		*o = DeviceCreatedBy(varDeviceCreatedBy)
+	err = json.Unmarshal(bytes, &varDeviceCreatedBy)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceCreatedBy(varDeviceCreatedBy)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_list.go
+++ b/metal/v1/model_device_list.go
@@ -135,9 +135,13 @@ func (o DeviceList) ToMap() (map[string]interface{}, error) {
 func (o *DeviceList) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceList := _DeviceList{}
 
-	if err = json.Unmarshal(bytes, &varDeviceList); err == nil {
-		*o = DeviceList(varDeviceList)
+	err = json.Unmarshal(bytes, &varDeviceList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceList(varDeviceList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_metro.go
+++ b/metal/v1/model_device_metro.go
@@ -207,9 +207,13 @@ func (o DeviceMetro) ToMap() (map[string]interface{}, error) {
 func (o *DeviceMetro) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceMetro := _DeviceMetro{}
 
-	if err = json.Unmarshal(bytes, &varDeviceMetro); err == nil {
-		*o = DeviceMetro(varDeviceMetro)
+	err = json.Unmarshal(bytes, &varDeviceMetro)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceMetro(varDeviceMetro)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_project_lite.go
+++ b/metal/v1/model_device_project_lite.go
@@ -90,9 +90,13 @@ func (o DeviceProjectLite) ToMap() (map[string]interface{}, error) {
 func (o *DeviceProjectLite) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceProjectLite := _DeviceProjectLite{}
 
-	if err = json.Unmarshal(bytes, &varDeviceProjectLite); err == nil {
-		*o = DeviceProjectLite(varDeviceProjectLite)
+	err = json.Unmarshal(bytes, &varDeviceProjectLite)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceProjectLite(varDeviceProjectLite)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_update_input.go
+++ b/metal/v1/model_device_update_input.go
@@ -462,9 +462,13 @@ func (o DeviceUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *DeviceUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceUpdateInput := _DeviceUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varDeviceUpdateInput); err == nil {
-		*o = DeviceUpdateInput(varDeviceUpdateInput)
+	err = json.Unmarshal(bytes, &varDeviceUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceUpdateInput(varDeviceUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_usage.go
+++ b/metal/v1/model_device_usage.go
@@ -171,9 +171,13 @@ func (o DeviceUsage) ToMap() (map[string]interface{}, error) {
 func (o *DeviceUsage) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceUsage := _DeviceUsage{}
 
-	if err = json.Unmarshal(bytes, &varDeviceUsage); err == nil {
-		*o = DeviceUsage(varDeviceUsage)
+	err = json.Unmarshal(bytes, &varDeviceUsage)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceUsage(varDeviceUsage)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_device_usage_list.go
+++ b/metal/v1/model_device_usage_list.go
@@ -99,9 +99,13 @@ func (o DeviceUsageList) ToMap() (map[string]interface{}, error) {
 func (o *DeviceUsageList) UnmarshalJSON(bytes []byte) (err error) {
 	varDeviceUsageList := _DeviceUsageList{}
 
-	if err = json.Unmarshal(bytes, &varDeviceUsageList); err == nil {
-		*o = DeviceUsageList(varDeviceUsageList)
+	err = json.Unmarshal(bytes, &varDeviceUsageList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = DeviceUsageList(varDeviceUsageList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_disk.go
+++ b/metal/v1/model_disk.go
@@ -171,9 +171,13 @@ func (o Disk) ToMap() (map[string]interface{}, error) {
 func (o *Disk) UnmarshalJSON(bytes []byte) (err error) {
 	varDisk := _Disk{}
 
-	if err = json.Unmarshal(bytes, &varDisk); err == nil {
-		*o = Disk(varDisk)
+	err = json.Unmarshal(bytes, &varDisk)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Disk(varDisk)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_email.go
+++ b/metal/v1/model_email.go
@@ -243,9 +243,13 @@ func (o Email) ToMap() (map[string]interface{}, error) {
 func (o *Email) UnmarshalJSON(bytes []byte) (err error) {
 	varEmail := _Email{}
 
-	if err = json.Unmarshal(bytes, &varEmail); err == nil {
-		*o = Email(varEmail)
+	err = json.Unmarshal(bytes, &varEmail)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Email(varEmail)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_email_input.go
+++ b/metal/v1/model_email_input.go
@@ -126,9 +126,13 @@ func (o EmailInput) ToMap() (map[string]interface{}, error) {
 func (o *EmailInput) UnmarshalJSON(bytes []byte) (err error) {
 	varEmailInput := _EmailInput{}
 
-	if err = json.Unmarshal(bytes, &varEmailInput); err == nil {
-		*o = EmailInput(varEmailInput)
+	err = json.Unmarshal(bytes, &varEmailInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = EmailInput(varEmailInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_entitlement.go
+++ b/metal/v1/model_entitlement.go
@@ -472,9 +472,13 @@ func (o Entitlement) ToMap() (map[string]interface{}, error) {
 func (o *Entitlement) UnmarshalJSON(bytes []byte) (err error) {
 	varEntitlement := _Entitlement{}
 
-	if err = json.Unmarshal(bytes, &varEntitlement); err == nil {
-		*o = Entitlement(varEntitlement)
+	err = json.Unmarshal(bytes, &varEntitlement)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Entitlement(varEntitlement)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_error.go
+++ b/metal/v1/model_error.go
@@ -137,9 +137,13 @@ func (o Error) ToMap() (map[string]interface{}, error) {
 func (o *Error) UnmarshalJSON(bytes []byte) (err error) {
 	varError := _Error{}
 
-	if err = json.Unmarshal(bytes, &varError); err == nil {
-		*o = Error(varError)
+	err = json.Unmarshal(bytes, &varError)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Error(varError)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_event.go
+++ b/metal/v1/model_event.go
@@ -424,9 +424,13 @@ func (o Event) ToMap() (map[string]interface{}, error) {
 func (o *Event) UnmarshalJSON(bytes []byte) (err error) {
 	varEvent := _Event{}
 
-	if err = json.Unmarshal(bytes, &varEvent); err == nil {
-		*o = Event(varEvent)
+	err = json.Unmarshal(bytes, &varEvent)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Event(varEvent)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_event_list.go
+++ b/metal/v1/model_event_list.go
@@ -135,9 +135,13 @@ func (o EventList) ToMap() (map[string]interface{}, error) {
 func (o *EventList) UnmarshalJSON(bytes []byte) (err error) {
 	varEventList := _EventList{}
 
-	if err = json.Unmarshal(bytes, &varEventList); err == nil {
-		*o = EventList(varEventList)
+	err = json.Unmarshal(bytes, &varEventList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = EventList(varEventList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_fabric_service_token.go
+++ b/metal/v1/model_fabric_service_token.go
@@ -286,9 +286,13 @@ func (o FabricServiceToken) ToMap() (map[string]interface{}, error) {
 func (o *FabricServiceToken) UnmarshalJSON(bytes []byte) (err error) {
 	varFabricServiceToken := _FabricServiceToken{}
 
-	if err = json.Unmarshal(bytes, &varFabricServiceToken); err == nil {
-		*o = FabricServiceToken(varFabricServiceToken)
+	err = json.Unmarshal(bytes, &varFabricServiceToken)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FabricServiceToken(varFabricServiceToken)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_facility.go
+++ b/metal/v1/model_facility.go
@@ -316,9 +316,13 @@ func (o Facility) ToMap() (map[string]interface{}, error) {
 func (o *Facility) UnmarshalJSON(bytes []byte) (err error) {
 	varFacility := _Facility{}
 
-	if err = json.Unmarshal(bytes, &varFacility); err == nil {
-		*o = Facility(varFacility)
+	err = json.Unmarshal(bytes, &varFacility)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Facility(varFacility)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_facility_input.go
+++ b/metal/v1/model_facility_input.go
@@ -95,9 +95,13 @@ func (o FacilityInput) ToMap() (map[string]interface{}, error) {
 func (o *FacilityInput) UnmarshalJSON(bytes []byte) (err error) {
 	varFacilityInput := _FacilityInput{}
 
-	if err = json.Unmarshal(bytes, &varFacilityInput); err == nil {
-		*o = FacilityInput(varFacilityInput)
+	err = json.Unmarshal(bytes, &varFacilityInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FacilityInput(varFacilityInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_facility_list.go
+++ b/metal/v1/model_facility_list.go
@@ -99,9 +99,13 @@ func (o FacilityList) ToMap() (map[string]interface{}, error) {
 func (o *FacilityList) UnmarshalJSON(bytes []byte) (err error) {
 	varFacilityList := _FacilityList{}
 
-	if err = json.Unmarshal(bytes, &varFacilityList); err == nil {
-		*o = FacilityList(varFacilityList)
+	err = json.Unmarshal(bytes, &varFacilityList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FacilityList(varFacilityList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_filesystem.go
+++ b/metal/v1/model_filesystem.go
@@ -99,9 +99,13 @@ func (o Filesystem) ToMap() (map[string]interface{}, error) {
 func (o *Filesystem) UnmarshalJSON(bytes []byte) (err error) {
 	varFilesystem := _Filesystem{}
 
-	if err = json.Unmarshal(bytes, &varFilesystem); err == nil {
-		*o = Filesystem(varFilesystem)
+	err = json.Unmarshal(bytes, &varFilesystem)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Filesystem(varFilesystem)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_find_traffic_timeframe_parameter.go
+++ b/metal/v1/model_find_traffic_timeframe_parameter.go
@@ -118,9 +118,13 @@ func (o FindTrafficTimeframeParameter) ToMap() (map[string]interface{}, error) {
 func (o *FindTrafficTimeframeParameter) UnmarshalJSON(bytes []byte) (err error) {
 	varFindTrafficTimeframeParameter := _FindTrafficTimeframeParameter{}
 
-	if err = json.Unmarshal(bytes, &varFindTrafficTimeframeParameter); err == nil {
-		*o = FindTrafficTimeframeParameter(varFindTrafficTimeframeParameter)
+	err = json.Unmarshal(bytes, &varFindTrafficTimeframeParameter)
+
+	if err != nil {
+		return err
 	}
+
+	*o = FindTrafficTimeframeParameter(varFindTrafficTimeframeParameter)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_global_bgp_range.go
+++ b/metal/v1/model_global_bgp_range.go
@@ -243,9 +243,13 @@ func (o GlobalBgpRange) ToMap() (map[string]interface{}, error) {
 func (o *GlobalBgpRange) UnmarshalJSON(bytes []byte) (err error) {
 	varGlobalBgpRange := _GlobalBgpRange{}
 
-	if err = json.Unmarshal(bytes, &varGlobalBgpRange); err == nil {
-		*o = GlobalBgpRange(varGlobalBgpRange)
+	err = json.Unmarshal(bytes, &varGlobalBgpRange)
+
+	if err != nil {
+		return err
 	}
+
+	*o = GlobalBgpRange(varGlobalBgpRange)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_global_bgp_range_list.go
+++ b/metal/v1/model_global_bgp_range_list.go
@@ -99,9 +99,13 @@ func (o GlobalBgpRangeList) ToMap() (map[string]interface{}, error) {
 func (o *GlobalBgpRangeList) UnmarshalJSON(bytes []byte) (err error) {
 	varGlobalBgpRangeList := _GlobalBgpRangeList{}
 
-	if err = json.Unmarshal(bytes, &varGlobalBgpRangeList); err == nil {
-		*o = GlobalBgpRangeList(varGlobalBgpRangeList)
+	err = json.Unmarshal(bytes, &varGlobalBgpRangeList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = GlobalBgpRangeList(varGlobalBgpRangeList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_hardware_reservation.go
+++ b/metal/v1/model_hardware_reservation.go
@@ -575,9 +575,13 @@ func (o HardwareReservation) ToMap() (map[string]interface{}, error) {
 func (o *HardwareReservation) UnmarshalJSON(bytes []byte) (err error) {
 	varHardwareReservation := _HardwareReservation{}
 
-	if err = json.Unmarshal(bytes, &varHardwareReservation); err == nil {
-		*o = HardwareReservation(varHardwareReservation)
+	err = json.Unmarshal(bytes, &varHardwareReservation)
+
+	if err != nil {
+		return err
 	}
+
+	*o = HardwareReservation(varHardwareReservation)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_hardware_reservation_list.go
+++ b/metal/v1/model_hardware_reservation_list.go
@@ -135,9 +135,13 @@ func (o HardwareReservationList) ToMap() (map[string]interface{}, error) {
 func (o *HardwareReservationList) UnmarshalJSON(bytes []byte) (err error) {
 	varHardwareReservationList := _HardwareReservationList{}
 
-	if err = json.Unmarshal(bytes, &varHardwareReservationList); err == nil {
-		*o = HardwareReservationList(varHardwareReservationList)
+	err = json.Unmarshal(bytes, &varHardwareReservationList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = HardwareReservationList(varHardwareReservationList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_href.go
+++ b/metal/v1/model_href.go
@@ -90,9 +90,13 @@ func (o Href) ToMap() (map[string]interface{}, error) {
 func (o *Href) UnmarshalJSON(bytes []byte) (err error) {
 	varHref := _Href{}
 
-	if err = json.Unmarshal(bytes, &varHref); err == nil {
-		*o = Href(varHref)
+	err = json.Unmarshal(bytes, &varHref)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Href(varHref)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_instances_batch_create_input.go
+++ b/metal/v1/model_instances_batch_create_input.go
@@ -99,9 +99,13 @@ func (o InstancesBatchCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *InstancesBatchCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varInstancesBatchCreateInput := _InstancesBatchCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varInstancesBatchCreateInput); err == nil {
-		*o = InstancesBatchCreateInput(varInstancesBatchCreateInput)
+	err = json.Unmarshal(bytes, &varInstancesBatchCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InstancesBatchCreateInput(varInstancesBatchCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_instances_batch_create_input_batches_inner.go
+++ b/metal/v1/model_instances_batch_create_input_batches_inner.go
@@ -1126,9 +1126,13 @@ func (o InstancesBatchCreateInputBatchesInner) ToMap() (map[string]interface{}, 
 func (o *InstancesBatchCreateInputBatchesInner) UnmarshalJSON(bytes []byte) (err error) {
 	varInstancesBatchCreateInputBatchesInner := _InstancesBatchCreateInputBatchesInner{}
 
-	if err = json.Unmarshal(bytes, &varInstancesBatchCreateInputBatchesInner); err == nil {
-		*o = InstancesBatchCreateInputBatchesInner(varInstancesBatchCreateInputBatchesInner)
+	err = json.Unmarshal(bytes, &varInstancesBatchCreateInputBatchesInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InstancesBatchCreateInputBatchesInner(varInstancesBatchCreateInputBatchesInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_interconnection.go
+++ b/metal/v1/model_interconnection.go
@@ -755,9 +755,13 @@ func (o Interconnection) ToMap() (map[string]interface{}, error) {
 func (o *Interconnection) UnmarshalJSON(bytes []byte) (err error) {
 	varInterconnection := _Interconnection{}
 
-	if err = json.Unmarshal(bytes, &varInterconnection); err == nil {
-		*o = Interconnection(varInterconnection)
+	err = json.Unmarshal(bytes, &varInterconnection)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Interconnection(varInterconnection)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_interconnection_list.go
+++ b/metal/v1/model_interconnection_list.go
@@ -135,9 +135,13 @@ func (o InterconnectionList) ToMap() (map[string]interface{}, error) {
 func (o *InterconnectionList) UnmarshalJSON(bytes []byte) (err error) {
 	varInterconnectionList := _InterconnectionList{}
 
-	if err = json.Unmarshal(bytes, &varInterconnectionList); err == nil {
-		*o = InterconnectionList(varInterconnectionList)
+	err = json.Unmarshal(bytes, &varInterconnectionList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InterconnectionList(varInterconnectionList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_interconnection_port.go
+++ b/metal/v1/model_interconnection_port.go
@@ -426,9 +426,13 @@ func (o InterconnectionPort) ToMap() (map[string]interface{}, error) {
 func (o *InterconnectionPort) UnmarshalJSON(bytes []byte) (err error) {
 	varInterconnectionPort := _InterconnectionPort{}
 
-	if err = json.Unmarshal(bytes, &varInterconnectionPort); err == nil {
-		*o = InterconnectionPort(varInterconnectionPort)
+	err = json.Unmarshal(bytes, &varInterconnectionPort)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InterconnectionPort(varInterconnectionPort)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_interconnection_port_list.go
+++ b/metal/v1/model_interconnection_port_list.go
@@ -99,9 +99,13 @@ func (o InterconnectionPortList) ToMap() (map[string]interface{}, error) {
 func (o *InterconnectionPortList) UnmarshalJSON(bytes []byte) (err error) {
 	varInterconnectionPortList := _InterconnectionPortList{}
 
-	if err = json.Unmarshal(bytes, &varInterconnectionPortList); err == nil {
-		*o = InterconnectionPortList(varInterconnectionPortList)
+	err = json.Unmarshal(bytes, &varInterconnectionPortList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InterconnectionPortList(varInterconnectionPortList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_interconnection_update_input.go
+++ b/metal/v1/model_interconnection_update_input.go
@@ -281,9 +281,13 @@ func (o InterconnectionUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *InterconnectionUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varInterconnectionUpdateInput := _InterconnectionUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varInterconnectionUpdateInput); err == nil {
-		*o = InterconnectionUpdateInput(varInterconnectionUpdateInput)
+	err = json.Unmarshal(bytes, &varInterconnectionUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InterconnectionUpdateInput(varInterconnectionUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_invitation.go
+++ b/metal/v1/model_invitation.go
@@ -460,9 +460,13 @@ func (o Invitation) ToMap() (map[string]interface{}, error) {
 func (o *Invitation) UnmarshalJSON(bytes []byte) (err error) {
 	varInvitation := _Invitation{}
 
-	if err = json.Unmarshal(bytes, &varInvitation); err == nil {
-		*o = Invitation(varInvitation)
+	err = json.Unmarshal(bytes, &varInvitation)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Invitation(varInvitation)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_invitation_input.go
+++ b/metal/v1/model_invitation_input.go
@@ -234,9 +234,13 @@ func (o InvitationInput) ToMap() (map[string]interface{}, error) {
 func (o *InvitationInput) UnmarshalJSON(bytes []byte) (err error) {
 	varInvitationInput := _InvitationInput{}
 
-	if err = json.Unmarshal(bytes, &varInvitationInput); err == nil {
-		*o = InvitationInput(varInvitationInput)
+	err = json.Unmarshal(bytes, &varInvitationInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InvitationInput(varInvitationInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_invitation_list.go
+++ b/metal/v1/model_invitation_list.go
@@ -99,9 +99,13 @@ func (o InvitationList) ToMap() (map[string]interface{}, error) {
 func (o *InvitationList) UnmarshalJSON(bytes []byte) (err error) {
 	varInvitationList := _InvitationList{}
 
-	if err = json.Unmarshal(bytes, &varInvitationList); err == nil {
-		*o = InvitationList(varInvitationList)
+	err = json.Unmarshal(bytes, &varInvitationList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InvitationList(varInvitationList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_invoice.go
+++ b/metal/v1/model_invoice.go
@@ -567,9 +567,13 @@ func (o Invoice) ToMap() (map[string]interface{}, error) {
 func (o *Invoice) UnmarshalJSON(bytes []byte) (err error) {
 	varInvoice := _Invoice{}
 
-	if err = json.Unmarshal(bytes, &varInvoice); err == nil {
-		*o = Invoice(varInvoice)
+	err = json.Unmarshal(bytes, &varInvoice)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Invoice(varInvoice)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_invoice_list.go
+++ b/metal/v1/model_invoice_list.go
@@ -99,9 +99,13 @@ func (o InvoiceList) ToMap() (map[string]interface{}, error) {
 func (o *InvoiceList) UnmarshalJSON(bytes []byte) (err error) {
 	varInvoiceList := _InvoiceList{}
 
-	if err = json.Unmarshal(bytes, &varInvoiceList); err == nil {
-		*o = InvoiceList(varInvoiceList)
+	err = json.Unmarshal(bytes, &varInvoiceList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = InvoiceList(varInvoiceList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_address.go
+++ b/metal/v1/model_ip_address.go
@@ -215,9 +215,13 @@ func (o IPAddress) ToMap() (map[string]interface{}, error) {
 func (o *IPAddress) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAddress := _IPAddress{}
 
-	if err = json.Unmarshal(bytes, &varIPAddress); err == nil {
-		*o = IPAddress(varIPAddress)
+	err = json.Unmarshal(bytes, &varIPAddress)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAddress(varIPAddress)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_assignment.go
+++ b/metal/v1/model_ip_assignment.go
@@ -750,9 +750,13 @@ func (o IPAssignment) ToMap() (map[string]interface{}, error) {
 func (o *IPAssignment) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAssignment := _IPAssignment{}
 
-	if err = json.Unmarshal(bytes, &varIPAssignment); err == nil {
-		*o = IPAssignment(varIPAssignment)
+	err = json.Unmarshal(bytes, &varIPAssignment)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAssignment(varIPAssignment)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_assignment_input.go
+++ b/metal/v1/model_ip_assignment_input.go
@@ -126,9 +126,13 @@ func (o IPAssignmentInput) ToMap() (map[string]interface{}, error) {
 func (o *IPAssignmentInput) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAssignmentInput := _IPAssignmentInput{}
 
-	if err = json.Unmarshal(bytes, &varIPAssignmentInput); err == nil {
-		*o = IPAssignmentInput(varIPAssignmentInput)
+	err = json.Unmarshal(bytes, &varIPAssignmentInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAssignmentInput(varIPAssignmentInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_assignment_list.go
+++ b/metal/v1/model_ip_assignment_list.go
@@ -99,9 +99,13 @@ func (o IPAssignmentList) ToMap() (map[string]interface{}, error) {
 func (o *IPAssignmentList) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAssignmentList := _IPAssignmentList{}
 
-	if err = json.Unmarshal(bytes, &varIPAssignmentList); err == nil {
-		*o = IPAssignmentList(varIPAssignmentList)
+	err = json.Unmarshal(bytes, &varIPAssignmentList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAssignmentList(varIPAssignmentList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_assignment_metro.go
+++ b/metal/v1/model_ip_assignment_metro.go
@@ -207,9 +207,13 @@ func (o IPAssignmentMetro) ToMap() (map[string]interface{}, error) {
 func (o *IPAssignmentMetro) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAssignmentMetro := _IPAssignmentMetro{}
 
-	if err = json.Unmarshal(bytes, &varIPAssignmentMetro); err == nil {
-		*o = IPAssignmentMetro(varIPAssignmentMetro)
+	err = json.Unmarshal(bytes, &varIPAssignmentMetro)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAssignmentMetro(varIPAssignmentMetro)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_assignment_update_input.go
+++ b/metal/v1/model_ip_assignment_update_input.go
@@ -171,9 +171,13 @@ func (o IPAssignmentUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *IPAssignmentUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAssignmentUpdateInput := _IPAssignmentUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varIPAssignmentUpdateInput); err == nil {
-		*o = IPAssignmentUpdateInput(varIPAssignmentUpdateInput)
+	err = json.Unmarshal(bytes, &varIPAssignmentUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAssignmentUpdateInput(varIPAssignmentUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_availabilities_list.go
+++ b/metal/v1/model_ip_availabilities_list.go
@@ -99,9 +99,13 @@ func (o IPAvailabilitiesList) ToMap() (map[string]interface{}, error) {
 func (o *IPAvailabilitiesList) UnmarshalJSON(bytes []byte) (err error) {
 	varIPAvailabilitiesList := _IPAvailabilitiesList{}
 
-	if err = json.Unmarshal(bytes, &varIPAvailabilitiesList); err == nil {
-		*o = IPAvailabilitiesList(varIPAvailabilitiesList)
+	err = json.Unmarshal(bytes, &varIPAvailabilitiesList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPAvailabilitiesList(varIPAvailabilitiesList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_reservation_facility.go
+++ b/metal/v1/model_ip_reservation_facility.go
@@ -316,9 +316,13 @@ func (o IPReservationFacility) ToMap() (map[string]interface{}, error) {
 func (o *IPReservationFacility) UnmarshalJSON(bytes []byte) (err error) {
 	varIPReservationFacility := _IPReservationFacility{}
 
-	if err = json.Unmarshal(bytes, &varIPReservationFacility); err == nil {
-		*o = IPReservationFacility(varIPReservationFacility)
+	err = json.Unmarshal(bytes, &varIPReservationFacility)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPReservationFacility(varIPReservationFacility)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_reservation_list.go
+++ b/metal/v1/model_ip_reservation_list.go
@@ -135,9 +135,13 @@ func (o IPReservationList) ToMap() (map[string]interface{}, error) {
 func (o *IPReservationList) UnmarshalJSON(bytes []byte) (err error) {
 	varIPReservationList := _IPReservationList{}
 
-	if err = json.Unmarshal(bytes, &varIPReservationList); err == nil {
-		*o = IPReservationList(varIPReservationList)
+	err = json.Unmarshal(bytes, &varIPReservationList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPReservationList(varIPReservationList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_reservation_metro.go
+++ b/metal/v1/model_ip_reservation_metro.go
@@ -207,9 +207,13 @@ func (o IPReservationMetro) ToMap() (map[string]interface{}, error) {
 func (o *IPReservationMetro) UnmarshalJSON(bytes []byte) (err error) {
 	varIPReservationMetro := _IPReservationMetro{}
 
-	if err = json.Unmarshal(bytes, &varIPReservationMetro); err == nil {
-		*o = IPReservationMetro(varIPReservationMetro)
+	err = json.Unmarshal(bytes, &varIPReservationMetro)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPReservationMetro(varIPReservationMetro)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ip_reservation_request_input.go
+++ b/metal/v1/model_ip_reservation_request_input.go
@@ -370,9 +370,13 @@ func (o IPReservationRequestInput) ToMap() (map[string]interface{}, error) {
 func (o *IPReservationRequestInput) UnmarshalJSON(bytes []byte) (err error) {
 	varIPReservationRequestInput := _IPReservationRequestInput{}
 
-	if err = json.Unmarshal(bytes, &varIPReservationRequestInput); err == nil {
-		*o = IPReservationRequestInput(varIPReservationRequestInput)
+	err = json.Unmarshal(bytes, &varIPReservationRequestInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = IPReservationRequestInput(varIPReservationRequestInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_license.go
+++ b/metal/v1/model_license.go
@@ -279,9 +279,13 @@ func (o License) ToMap() (map[string]interface{}, error) {
 func (o *License) UnmarshalJSON(bytes []byte) (err error) {
 	varLicense := _License{}
 
-	if err = json.Unmarshal(bytes, &varLicense); err == nil {
-		*o = License(varLicense)
+	err = json.Unmarshal(bytes, &varLicense)
+
+	if err != nil {
+		return err
 	}
+
+	*o = License(varLicense)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_license_create_input.go
+++ b/metal/v1/model_license_create_input.go
@@ -171,9 +171,13 @@ func (o LicenseCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *LicenseCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varLicenseCreateInput := _LicenseCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varLicenseCreateInput); err == nil {
-		*o = LicenseCreateInput(varLicenseCreateInput)
+	err = json.Unmarshal(bytes, &varLicenseCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = LicenseCreateInput(varLicenseCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_license_list.go
+++ b/metal/v1/model_license_list.go
@@ -99,9 +99,13 @@ func (o LicenseList) ToMap() (map[string]interface{}, error) {
 func (o *LicenseList) UnmarshalJSON(bytes []byte) (err error) {
 	varLicenseList := _LicenseList{}
 
-	if err = json.Unmarshal(bytes, &varLicenseList); err == nil {
-		*o = LicenseList(varLicenseList)
+	err = json.Unmarshal(bytes, &varLicenseList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = LicenseList(varLicenseList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_license_update_input.go
+++ b/metal/v1/model_license_update_input.go
@@ -135,9 +135,13 @@ func (o LicenseUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *LicenseUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varLicenseUpdateInput := _LicenseUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varLicenseUpdateInput); err == nil {
-		*o = LicenseUpdateInput(varLicenseUpdateInput)
+	err = json.Unmarshal(bytes, &varLicenseUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = LicenseUpdateInput(varLicenseUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_line_item.go
+++ b/metal/v1/model_line_item.go
@@ -315,9 +315,13 @@ func (o LineItem) ToMap() (map[string]interface{}, error) {
 func (o *LineItem) UnmarshalJSON(bytes []byte) (err error) {
 	varLineItem := _LineItem{}
 
-	if err = json.Unmarshal(bytes, &varLineItem); err == nil {
-		*o = LineItem(varLineItem)
+	err = json.Unmarshal(bytes, &varLineItem)
+
+	if err != nil {
+		return err
 	}
+
+	*o = LineItem(varLineItem)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_membership.go
+++ b/metal/v1/model_membership.go
@@ -316,9 +316,13 @@ func (o Membership) ToMap() (map[string]interface{}, error) {
 func (o *Membership) UnmarshalJSON(bytes []byte) (err error) {
 	varMembership := _Membership{}
 
-	if err = json.Unmarshal(bytes, &varMembership); err == nil {
-		*o = Membership(varMembership)
+	err = json.Unmarshal(bytes, &varMembership)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Membership(varMembership)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_membership_input.go
+++ b/metal/v1/model_membership_input.go
@@ -99,9 +99,13 @@ func (o MembershipInput) ToMap() (map[string]interface{}, error) {
 func (o *MembershipInput) UnmarshalJSON(bytes []byte) (err error) {
 	varMembershipInput := _MembershipInput{}
 
-	if err = json.Unmarshal(bytes, &varMembershipInput); err == nil {
-		*o = MembershipInput(varMembershipInput)
+	err = json.Unmarshal(bytes, &varMembershipInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MembershipInput(varMembershipInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_membership_list.go
+++ b/metal/v1/model_membership_list.go
@@ -99,9 +99,13 @@ func (o MembershipList) ToMap() (map[string]interface{}, error) {
 func (o *MembershipList) UnmarshalJSON(bytes []byte) (err error) {
 	varMembershipList := _MembershipList{}
 
-	if err = json.Unmarshal(bytes, &varMembershipList); err == nil {
-		*o = MembershipList(varMembershipList)
+	err = json.Unmarshal(bytes, &varMembershipList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MembershipList(varMembershipList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_meta.go
+++ b/metal/v1/model_meta.go
@@ -351,9 +351,13 @@ func (o Meta) ToMap() (map[string]interface{}, error) {
 func (o *Meta) UnmarshalJSON(bytes []byte) (err error) {
 	varMeta := _Meta{}
 
-	if err = json.Unmarshal(bytes, &varMeta); err == nil {
-		*o = Meta(varMeta)
+	err = json.Unmarshal(bytes, &varMeta)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Meta(varMeta)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metadata.go
+++ b/metal/v1/model_metadata.go
@@ -717,9 +717,13 @@ func (o Metadata) ToMap() (map[string]interface{}, error) {
 func (o *Metadata) UnmarshalJSON(bytes []byte) (err error) {
 	varMetadata := _Metadata{}
 
-	if err = json.Unmarshal(bytes, &varMetadata); err == nil {
-		*o = Metadata(varMetadata)
+	err = json.Unmarshal(bytes, &varMetadata)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Metadata(varMetadata)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metadata_network.go
+++ b/metal/v1/model_metadata_network.go
@@ -171,9 +171,13 @@ func (o MetadataNetwork) ToMap() (map[string]interface{}, error) {
 func (o *MetadataNetwork) UnmarshalJSON(bytes []byte) (err error) {
 	varMetadataNetwork := _MetadataNetwork{}
 
-	if err = json.Unmarshal(bytes, &varMetadataNetwork); err == nil {
-		*o = MetadataNetwork(varMetadataNetwork)
+	err = json.Unmarshal(bytes, &varMetadataNetwork)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetadataNetwork(varMetadataNetwork)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metadata_network_network.go
+++ b/metal/v1/model_metadata_network_network.go
@@ -99,9 +99,13 @@ func (o MetadataNetworkNetwork) ToMap() (map[string]interface{}, error) {
 func (o *MetadataNetworkNetwork) UnmarshalJSON(bytes []byte) (err error) {
 	varMetadataNetworkNetwork := _MetadataNetworkNetwork{}
 
-	if err = json.Unmarshal(bytes, &varMetadataNetworkNetwork); err == nil {
-		*o = MetadataNetworkNetwork(varMetadataNetworkNetwork)
+	err = json.Unmarshal(bytes, &varMetadataNetworkNetwork)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetadataNetworkNetwork(varMetadataNetworkNetwork)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metadata_network_network_bonding.go
+++ b/metal/v1/model_metadata_network_network_bonding.go
@@ -171,9 +171,13 @@ func (o MetadataNetworkNetworkBonding) ToMap() (map[string]interface{}, error) {
 func (o *MetadataNetworkNetworkBonding) UnmarshalJSON(bytes []byte) (err error) {
 	varMetadataNetworkNetworkBonding := _MetadataNetworkNetworkBonding{}
 
-	if err = json.Unmarshal(bytes, &varMetadataNetworkNetworkBonding); err == nil {
-		*o = MetadataNetworkNetworkBonding(varMetadataNetworkNetworkBonding)
+	err = json.Unmarshal(bytes, &varMetadataNetworkNetworkBonding)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetadataNetworkNetworkBonding(varMetadataNetworkNetworkBonding)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metal_gateway.go
+++ b/metal/v1/model_metal_gateway.go
@@ -389,9 +389,13 @@ func (o MetalGateway) ToMap() (map[string]interface{}, error) {
 func (o *MetalGateway) UnmarshalJSON(bytes []byte) (err error) {
 	varMetalGateway := _MetalGateway{}
 
-	if err = json.Unmarshal(bytes, &varMetalGateway); err == nil {
-		*o = MetalGateway(varMetalGateway)
+	err = json.Unmarshal(bytes, &varMetalGateway)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetalGateway(varMetalGateway)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metal_gateway_create_input.go
+++ b/metal/v1/model_metal_gateway_create_input.go
@@ -165,9 +165,13 @@ func (o MetalGatewayCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *MetalGatewayCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varMetalGatewayCreateInput := _MetalGatewayCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varMetalGatewayCreateInput); err == nil {
-		*o = MetalGatewayCreateInput(varMetalGatewayCreateInput)
+	err = json.Unmarshal(bytes, &varMetalGatewayCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetalGatewayCreateInput(varMetalGatewayCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metal_gateway_elastic_ip_create_input.go
+++ b/metal/v1/model_metal_gateway_elastic_ip_create_input.go
@@ -193,9 +193,13 @@ func (o MetalGatewayElasticIpCreateInput) ToMap() (map[string]interface{}, error
 func (o *MetalGatewayElasticIpCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varMetalGatewayElasticIpCreateInput := _MetalGatewayElasticIpCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varMetalGatewayElasticIpCreateInput); err == nil {
-		*o = MetalGatewayElasticIpCreateInput(varMetalGatewayElasticIpCreateInput)
+	err = json.Unmarshal(bytes, &varMetalGatewayElasticIpCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetalGatewayElasticIpCreateInput(varMetalGatewayElasticIpCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metal_gateway_list.go
+++ b/metal/v1/model_metal_gateway_list.go
@@ -135,9 +135,13 @@ func (o MetalGatewayList) ToMap() (map[string]interface{}, error) {
 func (o *MetalGatewayList) UnmarshalJSON(bytes []byte) (err error) {
 	varMetalGatewayList := _MetalGatewayList{}
 
-	if err = json.Unmarshal(bytes, &varMetalGatewayList); err == nil {
-		*o = MetalGatewayList(varMetalGatewayList)
+	err = json.Unmarshal(bytes, &varMetalGatewayList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetalGatewayList(varMetalGatewayList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metal_gateway_lite.go
+++ b/metal/v1/model_metal_gateway_lite.go
@@ -319,9 +319,13 @@ func (o MetalGatewayLite) ToMap() (map[string]interface{}, error) {
 func (o *MetalGatewayLite) UnmarshalJSON(bytes []byte) (err error) {
 	varMetalGatewayLite := _MetalGatewayLite{}
 
-	if err = json.Unmarshal(bytes, &varMetalGatewayLite); err == nil {
-		*o = MetalGatewayLite(varMetalGatewayLite)
+	err = json.Unmarshal(bytes, &varMetalGatewayLite)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetalGatewayLite(varMetalGatewayLite)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metro.go
+++ b/metal/v1/model_metro.go
@@ -207,9 +207,13 @@ func (o Metro) ToMap() (map[string]interface{}, error) {
 func (o *Metro) UnmarshalJSON(bytes []byte) (err error) {
 	varMetro := _Metro{}
 
-	if err = json.Unmarshal(bytes, &varMetro); err == nil {
-		*o = Metro(varMetro)
+	err = json.Unmarshal(bytes, &varMetro)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Metro(varMetro)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metro_input.go
+++ b/metal/v1/model_metro_input.go
@@ -91,9 +91,13 @@ func (o MetroInput) ToMap() (map[string]interface{}, error) {
 func (o *MetroInput) UnmarshalJSON(bytes []byte) (err error) {
 	varMetroInput := _MetroInput{}
 
-	if err = json.Unmarshal(bytes, &varMetroInput); err == nil {
-		*o = MetroInput(varMetroInput)
+	err = json.Unmarshal(bytes, &varMetroInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetroInput(varMetroInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_metro_list.go
+++ b/metal/v1/model_metro_list.go
@@ -99,9 +99,13 @@ func (o MetroList) ToMap() (map[string]interface{}, error) {
 func (o *MetroList) UnmarshalJSON(bytes []byte) (err error) {
 	varMetroList := _MetroList{}
 
-	if err = json.Unmarshal(bytes, &varMetroList); err == nil {
-		*o = MetroList(varMetroList)
+	err = json.Unmarshal(bytes, &varMetroList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MetroList(varMetroList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_mount.go
+++ b/metal/v1/model_mount.go
@@ -207,9 +207,13 @@ func (o Mount) ToMap() (map[string]interface{}, error) {
 func (o *Mount) UnmarshalJSON(bytes []byte) (err error) {
 	varMount := _Mount{}
 
-	if err = json.Unmarshal(bytes, &varMount); err == nil {
-		*o = Mount(varMount)
+	err = json.Unmarshal(bytes, &varMount)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Mount(varMount)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_move_hardware_reservation_request.go
+++ b/metal/v1/model_move_hardware_reservation_request.go
@@ -99,9 +99,13 @@ func (o MoveHardwareReservationRequest) ToMap() (map[string]interface{}, error) 
 func (o *MoveHardwareReservationRequest) UnmarshalJSON(bytes []byte) (err error) {
 	varMoveHardwareReservationRequest := _MoveHardwareReservationRequest{}
 
-	if err = json.Unmarshal(bytes, &varMoveHardwareReservationRequest); err == nil {
-		*o = MoveHardwareReservationRequest(varMoveHardwareReservationRequest)
+	err = json.Unmarshal(bytes, &varMoveHardwareReservationRequest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = MoveHardwareReservationRequest(varMoveHardwareReservationRequest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_new_password.go
+++ b/metal/v1/model_new_password.go
@@ -99,9 +99,13 @@ func (o NewPassword) ToMap() (map[string]interface{}, error) {
 func (o *NewPassword) UnmarshalJSON(bytes []byte) (err error) {
 	varNewPassword := _NewPassword{}
 
-	if err = json.Unmarshal(bytes, &varNewPassword); err == nil {
-		*o = NewPassword(varNewPassword)
+	err = json.Unmarshal(bytes, &varNewPassword)
+
+	if err != nil {
+		return err
 	}
+
+	*o = NewPassword(varNewPassword)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_operating_system.go
+++ b/metal/v1/model_operating_system.go
@@ -463,9 +463,13 @@ func (o OperatingSystem) ToMap() (map[string]interface{}, error) {
 func (o *OperatingSystem) UnmarshalJSON(bytes []byte) (err error) {
 	varOperatingSystem := _OperatingSystem{}
 
-	if err = json.Unmarshal(bytes, &varOperatingSystem); err == nil {
-		*o = OperatingSystem(varOperatingSystem)
+	err = json.Unmarshal(bytes, &varOperatingSystem)
+
+	if err != nil {
+		return err
 	}
+
+	*o = OperatingSystem(varOperatingSystem)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_operating_system_list.go
+++ b/metal/v1/model_operating_system_list.go
@@ -99,9 +99,13 @@ func (o OperatingSystemList) ToMap() (map[string]interface{}, error) {
 func (o *OperatingSystemList) UnmarshalJSON(bytes []byte) (err error) {
 	varOperatingSystemList := _OperatingSystemList{}
 
-	if err = json.Unmarshal(bytes, &varOperatingSystemList); err == nil {
-		*o = OperatingSystemList(varOperatingSystemList)
+	err = json.Unmarshal(bytes, &varOperatingSystemList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = OperatingSystemList(varOperatingSystemList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_organization.go
+++ b/metal/v1/model_organization.go
@@ -677,9 +677,13 @@ func (o Organization) ToMap() (map[string]interface{}, error) {
 func (o *Organization) UnmarshalJSON(bytes []byte) (err error) {
 	varOrganization := _Organization{}
 
-	if err = json.Unmarshal(bytes, &varOrganization); err == nil {
-		*o = Organization(varOrganization)
+	err = json.Unmarshal(bytes, &varOrganization)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Organization(varOrganization)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_organization_input.go
+++ b/metal/v1/model_organization_input.go
@@ -390,9 +390,13 @@ func (o OrganizationInput) ToMap() (map[string]interface{}, error) {
 func (o *OrganizationInput) UnmarshalJSON(bytes []byte) (err error) {
 	varOrganizationInput := _OrganizationInput{}
 
-	if err = json.Unmarshal(bytes, &varOrganizationInput); err == nil {
-		*o = OrganizationInput(varOrganizationInput)
+	err = json.Unmarshal(bytes, &varOrganizationInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = OrganizationInput(varOrganizationInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_organization_list.go
+++ b/metal/v1/model_organization_list.go
@@ -135,9 +135,13 @@ func (o OrganizationList) ToMap() (map[string]interface{}, error) {
 func (o *OrganizationList) UnmarshalJSON(bytes []byte) (err error) {
 	varOrganizationList := _OrganizationList{}
 
-	if err = json.Unmarshal(bytes, &varOrganizationList); err == nil {
-		*o = OrganizationList(varOrganizationList)
+	err = json.Unmarshal(bytes, &varOrganizationList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = OrganizationList(varOrganizationList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_parent_block.go
+++ b/metal/v1/model_parent_block.go
@@ -207,9 +207,13 @@ func (o ParentBlock) ToMap() (map[string]interface{}, error) {
 func (o *ParentBlock) UnmarshalJSON(bytes []byte) (err error) {
 	varParentBlock := _ParentBlock{}
 
-	if err = json.Unmarshal(bytes, &varParentBlock); err == nil {
-		*o = ParentBlock(varParentBlock)
+	err = json.Unmarshal(bytes, &varParentBlock)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ParentBlock(varParentBlock)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_partition.go
+++ b/metal/v1/model_partition.go
@@ -171,9 +171,13 @@ func (o Partition) ToMap() (map[string]interface{}, error) {
 func (o *Partition) UnmarshalJSON(bytes []byte) (err error) {
 	varPartition := _Partition{}
 
-	if err = json.Unmarshal(bytes, &varPartition); err == nil {
-		*o = Partition(varPartition)
+	err = json.Unmarshal(bytes, &varPartition)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Partition(varPartition)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_payment_method.go
+++ b/metal/v1/model_payment_method.go
@@ -604,9 +604,13 @@ func (o PaymentMethod) ToMap() (map[string]interface{}, error) {
 func (o *PaymentMethod) UnmarshalJSON(bytes []byte) (err error) {
 	varPaymentMethod := _PaymentMethod{}
 
-	if err = json.Unmarshal(bytes, &varPaymentMethod); err == nil {
-		*o = PaymentMethod(varPaymentMethod)
+	err = json.Unmarshal(bytes, &varPaymentMethod)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PaymentMethod(varPaymentMethod)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_payment_method_billing_address.go
+++ b/metal/v1/model_payment_method_billing_address.go
@@ -171,9 +171,13 @@ func (o PaymentMethodBillingAddress) ToMap() (map[string]interface{}, error) {
 func (o *PaymentMethodBillingAddress) UnmarshalJSON(bytes []byte) (err error) {
 	varPaymentMethodBillingAddress := _PaymentMethodBillingAddress{}
 
-	if err = json.Unmarshal(bytes, &varPaymentMethodBillingAddress); err == nil {
-		*o = PaymentMethodBillingAddress(varPaymentMethodBillingAddress)
+	err = json.Unmarshal(bytes, &varPaymentMethodBillingAddress)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PaymentMethodBillingAddress(varPaymentMethodBillingAddress)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_payment_method_create_input.go
+++ b/metal/v1/model_payment_method_create_input.go
@@ -153,9 +153,13 @@ func (o PaymentMethodCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *PaymentMethodCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varPaymentMethodCreateInput := _PaymentMethodCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varPaymentMethodCreateInput); err == nil {
-		*o = PaymentMethodCreateInput(varPaymentMethodCreateInput)
+	err = json.Unmarshal(bytes, &varPaymentMethodCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PaymentMethodCreateInput(varPaymentMethodCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_payment_method_list.go
+++ b/metal/v1/model_payment_method_list.go
@@ -99,9 +99,13 @@ func (o PaymentMethodList) ToMap() (map[string]interface{}, error) {
 func (o *PaymentMethodList) UnmarshalJSON(bytes []byte) (err error) {
 	varPaymentMethodList := _PaymentMethodList{}
 
-	if err = json.Unmarshal(bytes, &varPaymentMethodList); err == nil {
-		*o = PaymentMethodList(varPaymentMethodList)
+	err = json.Unmarshal(bytes, &varPaymentMethodList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PaymentMethodList(varPaymentMethodList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_payment_method_update_input.go
+++ b/metal/v1/model_payment_method_update_input.go
@@ -279,9 +279,13 @@ func (o PaymentMethodUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *PaymentMethodUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varPaymentMethodUpdateInput := _PaymentMethodUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varPaymentMethodUpdateInput); err == nil {
-		*o = PaymentMethodUpdateInput(varPaymentMethodUpdateInput)
+	err = json.Unmarshal(bytes, &varPaymentMethodUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PaymentMethodUpdateInput(varPaymentMethodUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan.go
+++ b/metal/v1/model_plan.go
@@ -572,9 +572,13 @@ func (o Plan) ToMap() (map[string]interface{}, error) {
 func (o *Plan) UnmarshalJSON(bytes []byte) (err error) {
 	varPlan := _Plan{}
 
-	if err = json.Unmarshal(bytes, &varPlan); err == nil {
-		*o = Plan(varPlan)
+	err = json.Unmarshal(bytes, &varPlan)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Plan(varPlan)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_available_in_inner.go
+++ b/metal/v1/model_plan_available_in_inner.go
@@ -136,9 +136,13 @@ func (o PlanAvailableInInner) ToMap() (map[string]interface{}, error) {
 func (o *PlanAvailableInInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanAvailableInInner := _PlanAvailableInInner{}
 
-	if err = json.Unmarshal(bytes, &varPlanAvailableInInner); err == nil {
-		*o = PlanAvailableInInner(varPlanAvailableInInner)
+	err = json.Unmarshal(bytes, &varPlanAvailableInInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanAvailableInInner(varPlanAvailableInInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_available_in_inner_price.go
+++ b/metal/v1/model_plan_available_in_inner_price.go
@@ -99,9 +99,13 @@ func (o PlanAvailableInInnerPrice) ToMap() (map[string]interface{}, error) {
 func (o *PlanAvailableInInnerPrice) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanAvailableInInnerPrice := _PlanAvailableInInnerPrice{}
 
-	if err = json.Unmarshal(bytes, &varPlanAvailableInInnerPrice); err == nil {
-		*o = PlanAvailableInInnerPrice(varPlanAvailableInInnerPrice)
+	err = json.Unmarshal(bytes, &varPlanAvailableInInnerPrice)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanAvailableInInnerPrice(varPlanAvailableInInnerPrice)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_available_in_metros_inner.go
+++ b/metal/v1/model_plan_available_in_metros_inner.go
@@ -136,9 +136,13 @@ func (o PlanAvailableInMetrosInner) ToMap() (map[string]interface{}, error) {
 func (o *PlanAvailableInMetrosInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanAvailableInMetrosInner := _PlanAvailableInMetrosInner{}
 
-	if err = json.Unmarshal(bytes, &varPlanAvailableInMetrosInner); err == nil {
-		*o = PlanAvailableInMetrosInner(varPlanAvailableInMetrosInner)
+	err = json.Unmarshal(bytes, &varPlanAvailableInMetrosInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanAvailableInMetrosInner(varPlanAvailableInMetrosInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_list.go
+++ b/metal/v1/model_plan_list.go
@@ -99,9 +99,13 @@ func (o PlanList) ToMap() (map[string]interface{}, error) {
 func (o *PlanList) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanList := _PlanList{}
 
-	if err = json.Unmarshal(bytes, &varPlanList); err == nil {
-		*o = PlanList(varPlanList)
+	err = json.Unmarshal(bytes, &varPlanList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanList(varPlanList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_specs.go
+++ b/metal/v1/model_plan_specs.go
@@ -243,9 +243,13 @@ func (o PlanSpecs) ToMap() (map[string]interface{}, error) {
 func (o *PlanSpecs) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanSpecs := _PlanSpecs{}
 
-	if err = json.Unmarshal(bytes, &varPlanSpecs); err == nil {
-		*o = PlanSpecs(varPlanSpecs)
+	err = json.Unmarshal(bytes, &varPlanSpecs)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanSpecs(varPlanSpecs)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_specs_cpus_inner.go
+++ b/metal/v1/model_plan_specs_cpus_inner.go
@@ -135,9 +135,13 @@ func (o PlanSpecsCpusInner) ToMap() (map[string]interface{}, error) {
 func (o *PlanSpecsCpusInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanSpecsCpusInner := _PlanSpecsCpusInner{}
 
-	if err = json.Unmarshal(bytes, &varPlanSpecsCpusInner); err == nil {
-		*o = PlanSpecsCpusInner(varPlanSpecsCpusInner)
+	err = json.Unmarshal(bytes, &varPlanSpecsCpusInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanSpecsCpusInner(varPlanSpecsCpusInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_specs_drives_inner.go
+++ b/metal/v1/model_plan_specs_drives_inner.go
@@ -207,9 +207,13 @@ func (o PlanSpecsDrivesInner) ToMap() (map[string]interface{}, error) {
 func (o *PlanSpecsDrivesInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanSpecsDrivesInner := _PlanSpecsDrivesInner{}
 
-	if err = json.Unmarshal(bytes, &varPlanSpecsDrivesInner); err == nil {
-		*o = PlanSpecsDrivesInner(varPlanSpecsDrivesInner)
+	err = json.Unmarshal(bytes, &varPlanSpecsDrivesInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanSpecsDrivesInner(varPlanSpecsDrivesInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_specs_features.go
+++ b/metal/v1/model_plan_specs_features.go
@@ -171,9 +171,13 @@ func (o PlanSpecsFeatures) ToMap() (map[string]interface{}, error) {
 func (o *PlanSpecsFeatures) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanSpecsFeatures := _PlanSpecsFeatures{}
 
-	if err = json.Unmarshal(bytes, &varPlanSpecsFeatures); err == nil {
-		*o = PlanSpecsFeatures(varPlanSpecsFeatures)
+	err = json.Unmarshal(bytes, &varPlanSpecsFeatures)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanSpecsFeatures(varPlanSpecsFeatures)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_specs_memory.go
+++ b/metal/v1/model_plan_specs_memory.go
@@ -99,9 +99,13 @@ func (o PlanSpecsMemory) ToMap() (map[string]interface{}, error) {
 func (o *PlanSpecsMemory) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanSpecsMemory := _PlanSpecsMemory{}
 
-	if err = json.Unmarshal(bytes, &varPlanSpecsMemory); err == nil {
-		*o = PlanSpecsMemory(varPlanSpecsMemory)
+	err = json.Unmarshal(bytes, &varPlanSpecsMemory)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanSpecsMemory(varPlanSpecsMemory)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_plan_specs_nics_inner.go
+++ b/metal/v1/model_plan_specs_nics_inner.go
@@ -135,9 +135,13 @@ func (o PlanSpecsNicsInner) ToMap() (map[string]interface{}, error) {
 func (o *PlanSpecsNicsInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPlanSpecsNicsInner := _PlanSpecsNicsInner{}
 
-	if err = json.Unmarshal(bytes, &varPlanSpecsNicsInner); err == nil {
-		*o = PlanSpecsNicsInner(varPlanSpecsNicsInner)
+	err = json.Unmarshal(bytes, &varPlanSpecsNicsInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PlanSpecsNicsInner(varPlanSpecsNicsInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port.go
+++ b/metal/v1/model_port.go
@@ -426,9 +426,13 @@ func (o Port) ToMap() (map[string]interface{}, error) {
 func (o *Port) UnmarshalJSON(bytes []byte) (err error) {
 	varPort := _Port{}
 
-	if err = json.Unmarshal(bytes, &varPort); err == nil {
-		*o = Port(varPort)
+	err = json.Unmarshal(bytes, &varPort)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Port(varPort)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_assign_input.go
+++ b/metal/v1/model_port_assign_input.go
@@ -100,9 +100,13 @@ func (o PortAssignInput) ToMap() (map[string]interface{}, error) {
 func (o *PortAssignInput) UnmarshalJSON(bytes []byte) (err error) {
 	varPortAssignInput := _PortAssignInput{}
 
-	if err = json.Unmarshal(bytes, &varPortAssignInput); err == nil {
-		*o = PortAssignInput(varPortAssignInput)
+	err = json.Unmarshal(bytes, &varPortAssignInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortAssignInput(varPortAssignInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_convert_layer3_input.go
+++ b/metal/v1/model_port_convert_layer3_input.go
@@ -99,9 +99,13 @@ func (o PortConvertLayer3Input) ToMap() (map[string]interface{}, error) {
 func (o *PortConvertLayer3Input) UnmarshalJSON(bytes []byte) (err error) {
 	varPortConvertLayer3Input := _PortConvertLayer3Input{}
 
-	if err = json.Unmarshal(bytes, &varPortConvertLayer3Input); err == nil {
-		*o = PortConvertLayer3Input(varPortConvertLayer3Input)
+	err = json.Unmarshal(bytes, &varPortConvertLayer3Input)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortConvertLayer3Input(varPortConvertLayer3Input)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_convert_layer3_input_request_ips_inner.go
+++ b/metal/v1/model_port_convert_layer3_input_request_ips_inner.go
@@ -135,9 +135,13 @@ func (o PortConvertLayer3InputRequestIpsInner) ToMap() (map[string]interface{}, 
 func (o *PortConvertLayer3InputRequestIpsInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPortConvertLayer3InputRequestIpsInner := _PortConvertLayer3InputRequestIpsInner{}
 
-	if err = json.Unmarshal(bytes, &varPortConvertLayer3InputRequestIpsInner); err == nil {
-		*o = PortConvertLayer3InputRequestIpsInner(varPortConvertLayer3InputRequestIpsInner)
+	err = json.Unmarshal(bytes, &varPortConvertLayer3InputRequestIpsInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortConvertLayer3InputRequestIpsInner(varPortConvertLayer3InputRequestIpsInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_data.go
+++ b/metal/v1/model_port_data.go
@@ -137,9 +137,13 @@ func (o PortData) ToMap() (map[string]interface{}, error) {
 func (o *PortData) UnmarshalJSON(bytes []byte) (err error) {
 	varPortData := _PortData{}
 
-	if err = json.Unmarshal(bytes, &varPortData); err == nil {
-		*o = PortData(varPortData)
+	err = json.Unmarshal(bytes, &varPortData)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortData(varPortData)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment.go
+++ b/metal/v1/model_port_vlan_assignment.go
@@ -352,9 +352,13 @@ func (o PortVlanAssignment) ToMap() (map[string]interface{}, error) {
 func (o *PortVlanAssignment) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignment := _PortVlanAssignment{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignment); err == nil {
-		*o = PortVlanAssignment(varPortVlanAssignment)
+	err = json.Unmarshal(bytes, &varPortVlanAssignment)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignment(varPortVlanAssignment)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment_batch.go
+++ b/metal/v1/model_port_vlan_assignment_batch.go
@@ -388,9 +388,13 @@ func (o PortVlanAssignmentBatch) ToMap() (map[string]interface{}, error) {
 func (o *PortVlanAssignmentBatch) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignmentBatch := _PortVlanAssignmentBatch{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatch); err == nil {
-		*o = PortVlanAssignmentBatch(varPortVlanAssignmentBatch)
+	err = json.Unmarshal(bytes, &varPortVlanAssignmentBatch)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignmentBatch(varPortVlanAssignmentBatch)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment_batch_create_input.go
+++ b/metal/v1/model_port_vlan_assignment_batch_create_input.go
@@ -99,9 +99,13 @@ func (o PortVlanAssignmentBatchCreateInput) ToMap() (map[string]interface{}, err
 func (o *PortVlanAssignmentBatchCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignmentBatchCreateInput := _PortVlanAssignmentBatchCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchCreateInput); err == nil {
-		*o = PortVlanAssignmentBatchCreateInput(varPortVlanAssignmentBatchCreateInput)
+	err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignmentBatchCreateInput(varPortVlanAssignmentBatchCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment_batch_create_input_vlan_assignments_inner.go
+++ b/metal/v1/model_port_vlan_assignment_batch_create_input_vlan_assignments_inner.go
@@ -171,9 +171,13 @@ func (o PortVlanAssignmentBatchCreateInputVlanAssignmentsInner) ToMap() (map[str
 func (o *PortVlanAssignmentBatchCreateInputVlanAssignmentsInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner := _PortVlanAssignmentBatchCreateInputVlanAssignmentsInner{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner); err == nil {
-		*o = PortVlanAssignmentBatchCreateInputVlanAssignmentsInner(varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner)
+	err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignmentBatchCreateInputVlanAssignmentsInner(varPortVlanAssignmentBatchCreateInputVlanAssignmentsInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment_batch_list.go
+++ b/metal/v1/model_port_vlan_assignment_batch_list.go
@@ -99,9 +99,13 @@ func (o PortVlanAssignmentBatchList) ToMap() (map[string]interface{}, error) {
 func (o *PortVlanAssignmentBatchList) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignmentBatchList := _PortVlanAssignmentBatchList{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchList); err == nil {
-		*o = PortVlanAssignmentBatchList(varPortVlanAssignmentBatchList)
+	err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignmentBatchList(varPortVlanAssignmentBatchList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment_batch_vlan_assignments_inner.go
+++ b/metal/v1/model_port_vlan_assignment_batch_vlan_assignments_inner.go
@@ -207,9 +207,13 @@ func (o PortVlanAssignmentBatchVlanAssignmentsInner) ToMap() (map[string]interfa
 func (o *PortVlanAssignmentBatchVlanAssignmentsInner) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignmentBatchVlanAssignmentsInner := _PortVlanAssignmentBatchVlanAssignmentsInner{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchVlanAssignmentsInner); err == nil {
-		*o = PortVlanAssignmentBatchVlanAssignmentsInner(varPortVlanAssignmentBatchVlanAssignmentsInner)
+	err = json.Unmarshal(bytes, &varPortVlanAssignmentBatchVlanAssignmentsInner)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignmentBatchVlanAssignmentsInner(varPortVlanAssignmentBatchVlanAssignmentsInner)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_port_vlan_assignment_list.go
+++ b/metal/v1/model_port_vlan_assignment_list.go
@@ -99,9 +99,13 @@ func (o PortVlanAssignmentList) ToMap() (map[string]interface{}, error) {
 func (o *PortVlanAssignmentList) UnmarshalJSON(bytes []byte) (err error) {
 	varPortVlanAssignmentList := _PortVlanAssignmentList{}
 
-	if err = json.Unmarshal(bytes, &varPortVlanAssignmentList); err == nil {
-		*o = PortVlanAssignmentList(varPortVlanAssignmentList)
+	err = json.Unmarshal(bytes, &varPortVlanAssignmentList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = PortVlanAssignmentList(varPortVlanAssignmentList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project.go
+++ b/metal/v1/model_project.go
@@ -713,9 +713,13 @@ func (o Project) ToMap() (map[string]interface{}, error) {
 func (o *Project) UnmarshalJSON(bytes []byte) (err error) {
 	varProject := _Project{}
 
-	if err = json.Unmarshal(bytes, &varProject); err == nil {
-		*o = Project(varProject)
+	err = json.Unmarshal(bytes, &varProject)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Project(varProject)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_create_from_root_input.go
+++ b/metal/v1/model_project_create_from_root_input.go
@@ -235,9 +235,13 @@ func (o ProjectCreateFromRootInput) ToMap() (map[string]interface{}, error) {
 func (o *ProjectCreateFromRootInput) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectCreateFromRootInput := _ProjectCreateFromRootInput{}
 
-	if err = json.Unmarshal(bytes, &varProjectCreateFromRootInput); err == nil {
-		*o = ProjectCreateFromRootInput(varProjectCreateFromRootInput)
+	err = json.Unmarshal(bytes, &varProjectCreateFromRootInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectCreateFromRootInput(varProjectCreateFromRootInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_create_input.go
+++ b/metal/v1/model_project_create_input.go
@@ -199,9 +199,13 @@ func (o ProjectCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *ProjectCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectCreateInput := _ProjectCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varProjectCreateInput); err == nil {
-		*o = ProjectCreateInput(varProjectCreateInput)
+	err = json.Unmarshal(bytes, &varProjectCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectCreateInput(varProjectCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_id_name.go
+++ b/metal/v1/model_project_id_name.go
@@ -135,9 +135,13 @@ func (o ProjectIdName) ToMap() (map[string]interface{}, error) {
 func (o *ProjectIdName) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectIdName := _ProjectIdName{}
 
-	if err = json.Unmarshal(bytes, &varProjectIdName); err == nil {
-		*o = ProjectIdName(varProjectIdName)
+	err = json.Unmarshal(bytes, &varProjectIdName)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectIdName(varProjectIdName)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_list.go
+++ b/metal/v1/model_project_list.go
@@ -135,9 +135,13 @@ func (o ProjectList) ToMap() (map[string]interface{}, error) {
 func (o *ProjectList) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectList := _ProjectList{}
 
-	if err = json.Unmarshal(bytes, &varProjectList); err == nil {
-		*o = ProjectList(varProjectList)
+	err = json.Unmarshal(bytes, &varProjectList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectList(varProjectList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_update_input.go
+++ b/metal/v1/model_project_update_input.go
@@ -244,9 +244,13 @@ func (o ProjectUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *ProjectUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectUpdateInput := _ProjectUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varProjectUpdateInput); err == nil {
-		*o = ProjectUpdateInput(varProjectUpdateInput)
+	err = json.Unmarshal(bytes, &varProjectUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectUpdateInput(varProjectUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_usage.go
+++ b/metal/v1/model_project_usage.go
@@ -387,9 +387,13 @@ func (o ProjectUsage) ToMap() (map[string]interface{}, error) {
 func (o *ProjectUsage) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectUsage := _ProjectUsage{}
 
-	if err = json.Unmarshal(bytes, &varProjectUsage); err == nil {
-		*o = ProjectUsage(varProjectUsage)
+	err = json.Unmarshal(bytes, &varProjectUsage)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectUsage(varProjectUsage)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_project_usage_list.go
+++ b/metal/v1/model_project_usage_list.go
@@ -99,9 +99,13 @@ func (o ProjectUsageList) ToMap() (map[string]interface{}, error) {
 func (o *ProjectUsageList) UnmarshalJSON(bytes []byte) (err error) {
 	varProjectUsageList := _ProjectUsageList{}
 
-	if err = json.Unmarshal(bytes, &varProjectUsageList); err == nil {
-		*o = ProjectUsageList(varProjectUsageList)
+	err = json.Unmarshal(bytes, &varProjectUsageList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ProjectUsageList(varProjectUsageList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_raid.go
+++ b/metal/v1/model_raid.go
@@ -171,9 +171,13 @@ func (o Raid) ToMap() (map[string]interface{}, error) {
 func (o *Raid) UnmarshalJSON(bytes []byte) (err error) {
 	varRaid := _Raid{}
 
-	if err = json.Unmarshal(bytes, &varRaid); err == nil {
-		*o = Raid(varRaid)
+	err = json.Unmarshal(bytes, &varRaid)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Raid(varRaid)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_recovery_code_list.go
+++ b/metal/v1/model_recovery_code_list.go
@@ -99,9 +99,13 @@ func (o RecoveryCodeList) ToMap() (map[string]interface{}, error) {
 func (o *RecoveryCodeList) UnmarshalJSON(bytes []byte) (err error) {
 	varRecoveryCodeList := _RecoveryCodeList{}
 
-	if err = json.Unmarshal(bytes, &varRecoveryCodeList); err == nil {
-		*o = RecoveryCodeList(varRecoveryCodeList)
+	err = json.Unmarshal(bytes, &varRecoveryCodeList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = RecoveryCodeList(varRecoveryCodeList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_self_service_reservation_item_request.go
+++ b/metal/v1/model_self_service_reservation_item_request.go
@@ -243,9 +243,13 @@ func (o SelfServiceReservationItemRequest) ToMap() (map[string]interface{}, erro
 func (o *SelfServiceReservationItemRequest) UnmarshalJSON(bytes []byte) (err error) {
 	varSelfServiceReservationItemRequest := _SelfServiceReservationItemRequest{}
 
-	if err = json.Unmarshal(bytes, &varSelfServiceReservationItemRequest); err == nil {
-		*o = SelfServiceReservationItemRequest(varSelfServiceReservationItemRequest)
+	err = json.Unmarshal(bytes, &varSelfServiceReservationItemRequest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SelfServiceReservationItemRequest(varSelfServiceReservationItemRequest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_self_service_reservation_item_response.go
+++ b/metal/v1/model_self_service_reservation_item_response.go
@@ -459,9 +459,13 @@ func (o SelfServiceReservationItemResponse) ToMap() (map[string]interface{}, err
 func (o *SelfServiceReservationItemResponse) UnmarshalJSON(bytes []byte) (err error) {
 	varSelfServiceReservationItemResponse := _SelfServiceReservationItemResponse{}
 
-	if err = json.Unmarshal(bytes, &varSelfServiceReservationItemResponse); err == nil {
-		*o = SelfServiceReservationItemResponse(varSelfServiceReservationItemResponse)
+	err = json.Unmarshal(bytes, &varSelfServiceReservationItemResponse)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SelfServiceReservationItemResponse(varSelfServiceReservationItemResponse)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_self_service_reservation_list.go
+++ b/metal/v1/model_self_service_reservation_list.go
@@ -99,9 +99,13 @@ func (o SelfServiceReservationList) ToMap() (map[string]interface{}, error) {
 func (o *SelfServiceReservationList) UnmarshalJSON(bytes []byte) (err error) {
 	varSelfServiceReservationList := _SelfServiceReservationList{}
 
-	if err = json.Unmarshal(bytes, &varSelfServiceReservationList); err == nil {
-		*o = SelfServiceReservationList(varSelfServiceReservationList)
+	err = json.Unmarshal(bytes, &varSelfServiceReservationList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SelfServiceReservationList(varSelfServiceReservationList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_self_service_reservation_response.go
+++ b/metal/v1/model_self_service_reservation_response.go
@@ -460,9 +460,13 @@ func (o SelfServiceReservationResponse) ToMap() (map[string]interface{}, error) 
 func (o *SelfServiceReservationResponse) UnmarshalJSON(bytes []byte) (err error) {
 	varSelfServiceReservationResponse := _SelfServiceReservationResponse{}
 
-	if err = json.Unmarshal(bytes, &varSelfServiceReservationResponse); err == nil {
-		*o = SelfServiceReservationResponse(varSelfServiceReservationResponse)
+	err = json.Unmarshal(bytes, &varSelfServiceReservationResponse)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SelfServiceReservationResponse(varSelfServiceReservationResponse)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_server_info.go
+++ b/metal/v1/model_server_info.go
@@ -214,9 +214,13 @@ func (o ServerInfo) ToMap() (map[string]interface{}, error) {
 func (o *ServerInfo) UnmarshalJSON(bytes []byte) (err error) {
 	varServerInfo := _ServerInfo{}
 
-	if err = json.Unmarshal(bytes, &varServerInfo); err == nil {
-		*o = ServerInfo(varServerInfo)
+	err = json.Unmarshal(bytes, &varServerInfo)
+
+	if err != nil {
+		return err
 	}
+
+	*o = ServerInfo(varServerInfo)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_prices_list.go
+++ b/metal/v1/model_spot_market_prices_list.go
@@ -99,9 +99,13 @@ func (o SpotMarketPricesList) ToMap() (map[string]interface{}, error) {
 func (o *SpotMarketPricesList) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketPricesList := _SpotMarketPricesList{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketPricesList); err == nil {
-		*o = SpotMarketPricesList(varSpotMarketPricesList)
+	err = json.Unmarshal(bytes, &varSpotMarketPricesList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketPricesList(varSpotMarketPricesList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_prices_per_metro_list.go
+++ b/metal/v1/model_spot_market_prices_per_metro_list.go
@@ -99,9 +99,13 @@ func (o SpotMarketPricesPerMetroList) ToMap() (map[string]interface{}, error) {
 func (o *SpotMarketPricesPerMetroList) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketPricesPerMetroList := _SpotMarketPricesPerMetroList{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketPricesPerMetroList); err == nil {
-		*o = SpotMarketPricesPerMetroList(varSpotMarketPricesPerMetroList)
+	err = json.Unmarshal(bytes, &varSpotMarketPricesPerMetroList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketPricesPerMetroList(varSpotMarketPricesPerMetroList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_prices_per_metro_report.go
+++ b/metal/v1/model_spot_market_prices_per_metro_report.go
@@ -315,9 +315,13 @@ func (o SpotMarketPricesPerMetroReport) ToMap() (map[string]interface{}, error) 
 func (o *SpotMarketPricesPerMetroReport) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketPricesPerMetroReport := _SpotMarketPricesPerMetroReport{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketPricesPerMetroReport); err == nil {
-		*o = SpotMarketPricesPerMetroReport(varSpotMarketPricesPerMetroReport)
+	err = json.Unmarshal(bytes, &varSpotMarketPricesPerMetroReport)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketPricesPerMetroReport(varSpotMarketPricesPerMetroReport)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_request.go
+++ b/metal/v1/model_spot_market_request.go
@@ -460,9 +460,13 @@ func (o SpotMarketRequest) ToMap() (map[string]interface{}, error) {
 func (o *SpotMarketRequest) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketRequest := _SpotMarketRequest{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketRequest); err == nil {
-		*o = SpotMarketRequest(varSpotMarketRequest)
+	err = json.Unmarshal(bytes, &varSpotMarketRequest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketRequest(varSpotMarketRequest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_request_create_input.go
+++ b/metal/v1/model_spot_market_request_create_input.go
@@ -321,9 +321,13 @@ func (o SpotMarketRequestCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *SpotMarketRequestCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketRequestCreateInput := _SpotMarketRequestCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketRequestCreateInput); err == nil {
-		*o = SpotMarketRequestCreateInput(varSpotMarketRequestCreateInput)
+	err = json.Unmarshal(bytes, &varSpotMarketRequestCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketRequestCreateInput(varSpotMarketRequestCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_request_create_input_instance_parameters.go
+++ b/metal/v1/model_spot_market_request_create_input_instance_parameters.go
@@ -714,9 +714,13 @@ func (o SpotMarketRequestCreateInputInstanceParameters) ToMap() (map[string]inte
 func (o *SpotMarketRequestCreateInputInstanceParameters) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketRequestCreateInputInstanceParameters := _SpotMarketRequestCreateInputInstanceParameters{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketRequestCreateInputInstanceParameters); err == nil {
-		*o = SpotMarketRequestCreateInputInstanceParameters(varSpotMarketRequestCreateInputInstanceParameters)
+	err = json.Unmarshal(bytes, &varSpotMarketRequestCreateInputInstanceParameters)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketRequestCreateInputInstanceParameters(varSpotMarketRequestCreateInputInstanceParameters)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_request_list.go
+++ b/metal/v1/model_spot_market_request_list.go
@@ -99,9 +99,13 @@ func (o SpotMarketRequestList) ToMap() (map[string]interface{}, error) {
 func (o *SpotMarketRequestList) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketRequestList := _SpotMarketRequestList{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketRequestList); err == nil {
-		*o = SpotMarketRequestList(varSpotMarketRequestList)
+	err = json.Unmarshal(bytes, &varSpotMarketRequestList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketRequestList(varSpotMarketRequestList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_market_request_metro.go
+++ b/metal/v1/model_spot_market_request_metro.go
@@ -207,9 +207,13 @@ func (o SpotMarketRequestMetro) ToMap() (map[string]interface{}, error) {
 func (o *SpotMarketRequestMetro) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotMarketRequestMetro := _SpotMarketRequestMetro{}
 
-	if err = json.Unmarshal(bytes, &varSpotMarketRequestMetro); err == nil {
-		*o = SpotMarketRequestMetro(varSpotMarketRequestMetro)
+	err = json.Unmarshal(bytes, &varSpotMarketRequestMetro)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotMarketRequestMetro(varSpotMarketRequestMetro)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_prices_datapoints.go
+++ b/metal/v1/model_spot_prices_datapoints.go
@@ -99,9 +99,13 @@ func (o SpotPricesDatapoints) ToMap() (map[string]interface{}, error) {
 func (o *SpotPricesDatapoints) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotPricesDatapoints := _SpotPricesDatapoints{}
 
-	if err = json.Unmarshal(bytes, &varSpotPricesDatapoints); err == nil {
-		*o = SpotPricesDatapoints(varSpotPricesDatapoints)
+	err = json.Unmarshal(bytes, &varSpotPricesDatapoints)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotPricesDatapoints(varSpotPricesDatapoints)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_prices_history_report.go
+++ b/metal/v1/model_spot_prices_history_report.go
@@ -99,9 +99,13 @@ func (o SpotPricesHistoryReport) ToMap() (map[string]interface{}, error) {
 func (o *SpotPricesHistoryReport) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotPricesHistoryReport := _SpotPricesHistoryReport{}
 
-	if err = json.Unmarshal(bytes, &varSpotPricesHistoryReport); err == nil {
-		*o = SpotPricesHistoryReport(varSpotPricesHistoryReport)
+	err = json.Unmarshal(bytes, &varSpotPricesHistoryReport)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotPricesHistoryReport(varSpotPricesHistoryReport)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_prices_per_baremetal.go
+++ b/metal/v1/model_spot_prices_per_baremetal.go
@@ -99,9 +99,13 @@ func (o SpotPricesPerBaremetal) ToMap() (map[string]interface{}, error) {
 func (o *SpotPricesPerBaremetal) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotPricesPerBaremetal := _SpotPricesPerBaremetal{}
 
-	if err = json.Unmarshal(bytes, &varSpotPricesPerBaremetal); err == nil {
-		*o = SpotPricesPerBaremetal(varSpotPricesPerBaremetal)
+	err = json.Unmarshal(bytes, &varSpotPricesPerBaremetal)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotPricesPerBaremetal(varSpotPricesPerBaremetal)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_prices_per_facility.go
+++ b/metal/v1/model_spot_prices_per_facility.go
@@ -387,9 +387,13 @@ func (o SpotPricesPerFacility) ToMap() (map[string]interface{}, error) {
 func (o *SpotPricesPerFacility) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotPricesPerFacility := _SpotPricesPerFacility{}
 
-	if err = json.Unmarshal(bytes, &varSpotPricesPerFacility); err == nil {
-		*o = SpotPricesPerFacility(varSpotPricesPerFacility)
+	err = json.Unmarshal(bytes, &varSpotPricesPerFacility)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotPricesPerFacility(varSpotPricesPerFacility)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_prices_per_new_facility.go
+++ b/metal/v1/model_spot_prices_per_new_facility.go
@@ -99,9 +99,13 @@ func (o SpotPricesPerNewFacility) ToMap() (map[string]interface{}, error) {
 func (o *SpotPricesPerNewFacility) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotPricesPerNewFacility := _SpotPricesPerNewFacility{}
 
-	if err = json.Unmarshal(bytes, &varSpotPricesPerNewFacility); err == nil {
-		*o = SpotPricesPerNewFacility(varSpotPricesPerNewFacility)
+	err = json.Unmarshal(bytes, &varSpotPricesPerNewFacility)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotPricesPerNewFacility(varSpotPricesPerNewFacility)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_spot_prices_report.go
+++ b/metal/v1/model_spot_prices_report.go
@@ -567,9 +567,13 @@ func (o SpotPricesReport) ToMap() (map[string]interface{}, error) {
 func (o *SpotPricesReport) UnmarshalJSON(bytes []byte) (err error) {
 	varSpotPricesReport := _SpotPricesReport{}
 
-	if err = json.Unmarshal(bytes, &varSpotPricesReport); err == nil {
-		*o = SpotPricesReport(varSpotPricesReport)
+	err = json.Unmarshal(bytes, &varSpotPricesReport)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SpotPricesReport(varSpotPricesReport)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ssh_key.go
+++ b/metal/v1/model_ssh_key.go
@@ -388,9 +388,13 @@ func (o SSHKey) ToMap() (map[string]interface{}, error) {
 func (o *SSHKey) UnmarshalJSON(bytes []byte) (err error) {
 	varSSHKey := _SSHKey{}
 
-	if err = json.Unmarshal(bytes, &varSSHKey); err == nil {
-		*o = SSHKey(varSSHKey)
+	err = json.Unmarshal(bytes, &varSSHKey)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SSHKey(varSSHKey)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ssh_key_create_input.go
+++ b/metal/v1/model_ssh_key_create_input.go
@@ -208,9 +208,13 @@ func (o SSHKeyCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *SSHKeyCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varSSHKeyCreateInput := _SSHKeyCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varSSHKeyCreateInput); err == nil {
-		*o = SSHKeyCreateInput(varSSHKeyCreateInput)
+	err = json.Unmarshal(bytes, &varSSHKeyCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SSHKeyCreateInput(varSSHKeyCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ssh_key_input.go
+++ b/metal/v1/model_ssh_key_input.go
@@ -171,9 +171,13 @@ func (o SSHKeyInput) ToMap() (map[string]interface{}, error) {
 func (o *SSHKeyInput) UnmarshalJSON(bytes []byte) (err error) {
 	varSSHKeyInput := _SSHKeyInput{}
 
-	if err = json.Unmarshal(bytes, &varSSHKeyInput); err == nil {
-		*o = SSHKeyInput(varSSHKeyInput)
+	err = json.Unmarshal(bytes, &varSSHKeyInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SSHKeyInput(varSSHKeyInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_ssh_key_list.go
+++ b/metal/v1/model_ssh_key_list.go
@@ -99,9 +99,13 @@ func (o SSHKeyList) ToMap() (map[string]interface{}, error) {
 func (o *SSHKeyList) UnmarshalJSON(bytes []byte) (err error) {
 	varSSHKeyList := _SSHKeyList{}
 
-	if err = json.Unmarshal(bytes, &varSSHKeyList); err == nil {
-		*o = SSHKeyList(varSSHKeyList)
+	err = json.Unmarshal(bytes, &varSSHKeyList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SSHKeyList(varSSHKeyList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_storage.go
+++ b/metal/v1/model_storage.go
@@ -171,9 +171,13 @@ func (o Storage) ToMap() (map[string]interface{}, error) {
 func (o *Storage) UnmarshalJSON(bytes []byte) (err error) {
 	varStorage := _Storage{}
 
-	if err = json.Unmarshal(bytes, &varStorage); err == nil {
-		*o = Storage(varStorage)
+	err = json.Unmarshal(bytes, &varStorage)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Storage(varStorage)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_support_request_input.go
+++ b/metal/v1/model_support_request_input.go
@@ -225,9 +225,13 @@ func (o SupportRequestInput) ToMap() (map[string]interface{}, error) {
 func (o *SupportRequestInput) UnmarshalJSON(bytes []byte) (err error) {
 	varSupportRequestInput := _SupportRequestInput{}
 
-	if err = json.Unmarshal(bytes, &varSupportRequestInput); err == nil {
-		*o = SupportRequestInput(varSupportRequestInput)
+	err = json.Unmarshal(bytes, &varSupportRequestInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = SupportRequestInput(varSupportRequestInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_transfer_request.go
+++ b/metal/v1/model_transfer_request.go
@@ -280,9 +280,13 @@ func (o TransferRequest) ToMap() (map[string]interface{}, error) {
 func (o *TransferRequest) UnmarshalJSON(bytes []byte) (err error) {
 	varTransferRequest := _TransferRequest{}
 
-	if err = json.Unmarshal(bytes, &varTransferRequest); err == nil {
-		*o = TransferRequest(varTransferRequest)
+	err = json.Unmarshal(bytes, &varTransferRequest)
+
+	if err != nil {
+		return err
 	}
+
+	*o = TransferRequest(varTransferRequest)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_transfer_request_input.go
+++ b/metal/v1/model_transfer_request_input.go
@@ -99,9 +99,13 @@ func (o TransferRequestInput) ToMap() (map[string]interface{}, error) {
 func (o *TransferRequestInput) UnmarshalJSON(bytes []byte) (err error) {
 	varTransferRequestInput := _TransferRequestInput{}
 
-	if err = json.Unmarshal(bytes, &varTransferRequestInput); err == nil {
-		*o = TransferRequestInput(varTransferRequestInput)
+	err = json.Unmarshal(bytes, &varTransferRequestInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = TransferRequestInput(varTransferRequestInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_transfer_request_list.go
+++ b/metal/v1/model_transfer_request_list.go
@@ -99,9 +99,13 @@ func (o TransferRequestList) ToMap() (map[string]interface{}, error) {
 func (o *TransferRequestList) UnmarshalJSON(bytes []byte) (err error) {
 	varTransferRequestList := _TransferRequestList{}
 
-	if err = json.Unmarshal(bytes, &varTransferRequestList); err == nil {
-		*o = TransferRequestList(varTransferRequestList)
+	err = json.Unmarshal(bytes, &varTransferRequestList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = TransferRequestList(varTransferRequestList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_update_email_input.go
+++ b/metal/v1/model_update_email_input.go
@@ -99,9 +99,13 @@ func (o UpdateEmailInput) ToMap() (map[string]interface{}, error) {
 func (o *UpdateEmailInput) UnmarshalJSON(bytes []byte) (err error) {
 	varUpdateEmailInput := _UpdateEmailInput{}
 
-	if err = json.Unmarshal(bytes, &varUpdateEmailInput); err == nil {
-		*o = UpdateEmailInput(varUpdateEmailInput)
+	err = json.Unmarshal(bytes, &varUpdateEmailInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = UpdateEmailInput(varUpdateEmailInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_user.go
+++ b/metal/v1/model_user.go
@@ -856,9 +856,13 @@ func (o User) ToMap() (map[string]interface{}, error) {
 func (o *User) UnmarshalJSON(bytes []byte) (err error) {
 	varUser := _User{}
 
-	if err = json.Unmarshal(bytes, &varUser); err == nil {
-		*o = User(varUser)
+	err = json.Unmarshal(bytes, &varUser)
+
+	if err != nil {
+		return err
 	}
+
+	*o = User(varUser)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_user_create_input.go
+++ b/metal/v1/model_user_create_input.go
@@ -650,9 +650,13 @@ func (o UserCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *UserCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varUserCreateInput := _UserCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varUserCreateInput); err == nil {
-		*o = UserCreateInput(varUserCreateInput)
+	err = json.Unmarshal(bytes, &varUserCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = UserCreateInput(varUserCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_user_limited.go
+++ b/metal/v1/model_user_limited.go
@@ -239,9 +239,13 @@ func (o UserLimited) ToMap() (map[string]interface{}, error) {
 func (o *UserLimited) UnmarshalJSON(bytes []byte) (err error) {
 	varUserLimited := _UserLimited{}
 
-	if err = json.Unmarshal(bytes, &varUserLimited); err == nil {
-		*o = UserLimited(varUserLimited)
+	err = json.Unmarshal(bytes, &varUserLimited)
+
+	if err != nil {
+		return err
 	}
+
+	*o = UserLimited(varUserLimited)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_user_list.go
+++ b/metal/v1/model_user_list.go
@@ -135,9 +135,13 @@ func (o UserList) ToMap() (map[string]interface{}, error) {
 func (o *UserList) UnmarshalJSON(bytes []byte) (err error) {
 	varUserList := _UserList{}
 
-	if err = json.Unmarshal(bytes, &varUserList); err == nil {
-		*o = UserList(varUserList)
+	err = json.Unmarshal(bytes, &varUserList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = UserList(varUserList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_user_lite.go
+++ b/metal/v1/model_user_lite.go
@@ -416,9 +416,13 @@ func (o UserLite) ToMap() (map[string]interface{}, error) {
 func (o *UserLite) UnmarshalJSON(bytes []byte) (err error) {
 	varUserLite := _UserLite{}
 
-	if err = json.Unmarshal(bytes, &varUserLite); err == nil {
-		*o = UserLite(varUserLite)
+	err = json.Unmarshal(bytes, &varUserLite)
+
+	if err != nil {
+		return err
 	}
+
+	*o = UserLite(varUserLite)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_user_update_input.go
+++ b/metal/v1/model_user_update_input.go
@@ -279,9 +279,13 @@ func (o UserUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *UserUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varUserUpdateInput := _UserUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varUserUpdateInput); err == nil {
-		*o = UserUpdateInput(varUserUpdateInput)
+	err = json.Unmarshal(bytes, &varUserUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = UserUpdateInput(varUserUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_userdata.go
+++ b/metal/v1/model_userdata.go
@@ -99,9 +99,13 @@ func (o Userdata) ToMap() (map[string]interface{}, error) {
 func (o *Userdata) UnmarshalJSON(bytes []byte) (err error) {
 	varUserdata := _Userdata{}
 
-	if err = json.Unmarshal(bytes, &varUserdata); err == nil {
-		*o = Userdata(varUserdata)
+	err = json.Unmarshal(bytes, &varUserdata)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Userdata(varUserdata)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_verify_email.go
+++ b/metal/v1/model_verify_email.go
@@ -91,9 +91,13 @@ func (o VerifyEmail) ToMap() (map[string]interface{}, error) {
 func (o *VerifyEmail) UnmarshalJSON(bytes []byte) (err error) {
 	varVerifyEmail := _VerifyEmail{}
 
-	if err = json.Unmarshal(bytes, &varVerifyEmail); err == nil {
-		*o = VerifyEmail(varVerifyEmail)
+	err = json.Unmarshal(bytes, &varVerifyEmail)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VerifyEmail(varVerifyEmail)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_virtual_circuit_list.go
+++ b/metal/v1/model_virtual_circuit_list.go
@@ -99,9 +99,13 @@ func (o VirtualCircuitList) ToMap() (map[string]interface{}, error) {
 func (o *VirtualCircuitList) UnmarshalJSON(bytes []byte) (err error) {
 	varVirtualCircuitList := _VirtualCircuitList{}
 
-	if err = json.Unmarshal(bytes, &varVirtualCircuitList); err == nil {
-		*o = VirtualCircuitList(varVirtualCircuitList)
+	err = json.Unmarshal(bytes, &varVirtualCircuitList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VirtualCircuitList(varVirtualCircuitList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_virtual_network.go
+++ b/metal/v1/model_virtual_network.go
@@ -536,9 +536,13 @@ func (o VirtualNetwork) ToMap() (map[string]interface{}, error) {
 func (o *VirtualNetwork) UnmarshalJSON(bytes []byte) (err error) {
 	varVirtualNetwork := _VirtualNetwork{}
 
-	if err = json.Unmarshal(bytes, &varVirtualNetwork); err == nil {
-		*o = VirtualNetwork(varVirtualNetwork)
+	err = json.Unmarshal(bytes, &varVirtualNetwork)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VirtualNetwork(varVirtualNetwork)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_virtual_network_create_input.go
+++ b/metal/v1/model_virtual_network_create_input.go
@@ -250,9 +250,13 @@ func (o VirtualNetworkCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VirtualNetworkCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVirtualNetworkCreateInput := _VirtualNetworkCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVirtualNetworkCreateInput); err == nil {
-		*o = VirtualNetworkCreateInput(varVirtualNetworkCreateInput)
+	err = json.Unmarshal(bytes, &varVirtualNetworkCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VirtualNetworkCreateInput(varVirtualNetworkCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_virtual_network_list.go
+++ b/metal/v1/model_virtual_network_list.go
@@ -99,9 +99,13 @@ func (o VirtualNetworkList) ToMap() (map[string]interface{}, error) {
 func (o *VirtualNetworkList) UnmarshalJSON(bytes []byte) (err error) {
 	varVirtualNetworkList := _VirtualNetworkList{}
 
-	if err = json.Unmarshal(bytes, &varVirtualNetworkList); err == nil {
-		*o = VirtualNetworkList(varVirtualNetworkList)
+	err = json.Unmarshal(bytes, &varVirtualNetworkList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VirtualNetworkList(varVirtualNetworkList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vlan_fabric_vc_create_input.go
+++ b/metal/v1/model_vlan_fabric_vc_create_input.go
@@ -421,9 +421,13 @@ func (o VlanFabricVcCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VlanFabricVcCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVlanFabricVcCreateInput := _VlanFabricVcCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVlanFabricVcCreateInput); err == nil {
-		*o = VlanFabricVcCreateInput(varVlanFabricVcCreateInput)
+	err = json.Unmarshal(bytes, &varVlanFabricVcCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VlanFabricVcCreateInput(varVlanFabricVcCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vlan_virtual_circuit.go
+++ b/metal/v1/model_vlan_virtual_circuit.go
@@ -474,9 +474,13 @@ func (o VlanVirtualCircuit) ToMap() (map[string]interface{}, error) {
 func (o *VlanVirtualCircuit) UnmarshalJSON(bytes []byte) (err error) {
 	varVlanVirtualCircuit := _VlanVirtualCircuit{}
 
-	if err = json.Unmarshal(bytes, &varVlanVirtualCircuit); err == nil {
-		*o = VlanVirtualCircuit(varVlanVirtualCircuit)
+	err = json.Unmarshal(bytes, &varVlanVirtualCircuit)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VlanVirtualCircuit(varVlanVirtualCircuit)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vlan_virtual_circuit_create_input.go
+++ b/metal/v1/model_vlan_virtual_circuit_create_input.go
@@ -308,9 +308,13 @@ func (o VlanVirtualCircuitCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VlanVirtualCircuitCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVlanVirtualCircuitCreateInput := _VlanVirtualCircuitCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVlanVirtualCircuitCreateInput); err == nil {
-		*o = VlanVirtualCircuitCreateInput(varVlanVirtualCircuitCreateInput)
+	err = json.Unmarshal(bytes, &varVlanVirtualCircuitCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VlanVirtualCircuitCreateInput(varVlanVirtualCircuitCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vlan_virtual_circuit_update_input.go
+++ b/metal/v1/model_vlan_virtual_circuit_update_input.go
@@ -245,9 +245,13 @@ func (o VlanVirtualCircuitUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *VlanVirtualCircuitUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVlanVirtualCircuitUpdateInput := _VlanVirtualCircuitUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varVlanVirtualCircuitUpdateInput); err == nil {
-		*o = VlanVirtualCircuitUpdateInput(varVlanVirtualCircuitUpdateInput)
+	err = json.Unmarshal(bytes, &varVlanVirtualCircuitUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VlanVirtualCircuitUpdateInput(varVlanVirtualCircuitUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf.go
+++ b/metal/v1/model_vrf.go
@@ -688,9 +688,13 @@ func (o Vrf) ToMap() (map[string]interface{}, error) {
 func (o *Vrf) UnmarshalJSON(bytes []byte) (err error) {
 	varVrf := _Vrf{}
 
-	if err = json.Unmarshal(bytes, &varVrf); err == nil {
-		*o = Vrf(varVrf)
+	err = json.Unmarshal(bytes, &varVrf)
+
+	if err != nil {
+		return err
 	}
+
+	*o = Vrf(varVrf)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_create_input.go
+++ b/metal/v1/model_vrf_create_input.go
@@ -374,9 +374,13 @@ func (o VrfCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfCreateInput := _VrfCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfCreateInput); err == nil {
-		*o = VrfCreateInput(varVrfCreateInput)
+	err = json.Unmarshal(bytes, &varVrfCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfCreateInput(varVrfCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_fabric_vc_create_input.go
+++ b/metal/v1/model_vrf_fabric_vc_create_input.go
@@ -412,9 +412,13 @@ func (o VrfFabricVcCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfFabricVcCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfFabricVcCreateInput := _VrfFabricVcCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfFabricVcCreateInput); err == nil {
-		*o = VrfFabricVcCreateInput(varVrfFabricVcCreateInput)
+	err = json.Unmarshal(bytes, &varVrfFabricVcCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfFabricVcCreateInput(varVrfFabricVcCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_ip_reservation.go
+++ b/metal/v1/model_vrf_ip_reservation.go
@@ -910,9 +910,13 @@ func (o VrfIpReservation) ToMap() (map[string]interface{}, error) {
 func (o *VrfIpReservation) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfIpReservation := _VrfIpReservation{}
 
-	if err = json.Unmarshal(bytes, &varVrfIpReservation); err == nil {
-		*o = VrfIpReservation(varVrfIpReservation)
+	err = json.Unmarshal(bytes, &varVrfIpReservation)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfIpReservation(varVrfIpReservation)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_ip_reservation_create_input.go
+++ b/metal/v1/model_vrf_ip_reservation_create_input.go
@@ -283,9 +283,13 @@ func (o VrfIpReservationCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfIpReservationCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfIpReservationCreateInput := _VrfIpReservationCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfIpReservationCreateInput); err == nil {
-		*o = VrfIpReservationCreateInput(varVrfIpReservationCreateInput)
+	err = json.Unmarshal(bytes, &varVrfIpReservationCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfIpReservationCreateInput(varVrfIpReservationCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_ip_reservation_list.go
+++ b/metal/v1/model_vrf_ip_reservation_list.go
@@ -99,9 +99,13 @@ func (o VrfIpReservationList) ToMap() (map[string]interface{}, error) {
 func (o *VrfIpReservationList) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfIpReservationList := _VrfIpReservationList{}
 
-	if err = json.Unmarshal(bytes, &varVrfIpReservationList); err == nil {
-		*o = VrfIpReservationList(varVrfIpReservationList)
+	err = json.Unmarshal(bytes, &varVrfIpReservationList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfIpReservationList(varVrfIpReservationList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_list.go
+++ b/metal/v1/model_vrf_list.go
@@ -99,9 +99,13 @@ func (o VrfList) ToMap() (map[string]interface{}, error) {
 func (o *VrfList) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfList := _VrfList{}
 
-	if err = json.Unmarshal(bytes, &varVrfList); err == nil {
-		*o = VrfList(varVrfList)
+	err = json.Unmarshal(bytes, &varVrfList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfList(varVrfList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_metal_gateway.go
+++ b/metal/v1/model_vrf_metal_gateway.go
@@ -425,9 +425,13 @@ func (o VrfMetalGateway) ToMap() (map[string]interface{}, error) {
 func (o *VrfMetalGateway) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfMetalGateway := _VrfMetalGateway{}
 
-	if err = json.Unmarshal(bytes, &varVrfMetalGateway); err == nil {
-		*o = VrfMetalGateway(varVrfMetalGateway)
+	err = json.Unmarshal(bytes, &varVrfMetalGateway)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfMetalGateway(varVrfMetalGateway)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_metal_gateway_create_input.go
+++ b/metal/v1/model_vrf_metal_gateway_create_input.go
@@ -119,9 +119,13 @@ func (o VrfMetalGatewayCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfMetalGatewayCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfMetalGatewayCreateInput := _VrfMetalGatewayCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfMetalGatewayCreateInput); err == nil {
-		*o = VrfMetalGatewayCreateInput(varVrfMetalGatewayCreateInput)
+	err = json.Unmarshal(bytes, &varVrfMetalGatewayCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfMetalGatewayCreateInput(varVrfMetalGatewayCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_route.go
+++ b/metal/v1/model_vrf_route.go
@@ -501,9 +501,13 @@ func (o VrfRoute) ToMap() (map[string]interface{}, error) {
 func (o *VrfRoute) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfRoute := _VrfRoute{}
 
-	if err = json.Unmarshal(bytes, &varVrfRoute); err == nil {
-		*o = VrfRoute(varVrfRoute)
+	err = json.Unmarshal(bytes, &varVrfRoute)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfRoute(varVrfRoute)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_route_create_input.go
+++ b/metal/v1/model_vrf_route_create_input.go
@@ -155,9 +155,13 @@ func (o VrfRouteCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfRouteCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfRouteCreateInput := _VrfRouteCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfRouteCreateInput); err == nil {
-		*o = VrfRouteCreateInput(varVrfRouteCreateInput)
+	err = json.Unmarshal(bytes, &varVrfRouteCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfRouteCreateInput(varVrfRouteCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_route_list.go
+++ b/metal/v1/model_vrf_route_list.go
@@ -135,9 +135,13 @@ func (o VrfRouteList) ToMap() (map[string]interface{}, error) {
 func (o *VrfRouteList) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfRouteList := _VrfRouteList{}
 
-	if err = json.Unmarshal(bytes, &varVrfRouteList); err == nil {
-		*o = VrfRouteList(varVrfRouteList)
+	err = json.Unmarshal(bytes, &varVrfRouteList)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfRouteList(varVrfRouteList)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_route_update_input.go
+++ b/metal/v1/model_vrf_route_update_input.go
@@ -173,9 +173,13 @@ func (o VrfRouteUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfRouteUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfRouteUpdateInput := _VrfRouteUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfRouteUpdateInput); err == nil {
-		*o = VrfRouteUpdateInput(varVrfRouteUpdateInput)
+	err = json.Unmarshal(bytes, &varVrfRouteUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfRouteUpdateInput(varVrfRouteUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_update_input.go
+++ b/metal/v1/model_vrf_update_input.go
@@ -356,9 +356,13 @@ func (o VrfUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfUpdateInput := _VrfUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfUpdateInput); err == nil {
-		*o = VrfUpdateInput(varVrfUpdateInput)
+	err = json.Unmarshal(bytes, &varVrfUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfUpdateInput(varVrfUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_virtual_circuit.go
+++ b/metal/v1/model_vrf_virtual_circuit.go
@@ -683,9 +683,13 @@ func (o VrfVirtualCircuit) ToMap() (map[string]interface{}, error) {
 func (o *VrfVirtualCircuit) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfVirtualCircuit := _VrfVirtualCircuit{}
 
-	if err = json.Unmarshal(bytes, &varVrfVirtualCircuit); err == nil {
-		*o = VrfVirtualCircuit(varVrfVirtualCircuit)
+	err = json.Unmarshal(bytes, &varVrfVirtualCircuit)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfVirtualCircuit(varVrfVirtualCircuit)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_virtual_circuit_create_input.go
+++ b/metal/v1/model_vrf_virtual_circuit_create_input.go
@@ -468,9 +468,13 @@ func (o VrfVirtualCircuitCreateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfVirtualCircuitCreateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfVirtualCircuitCreateInput := _VrfVirtualCircuitCreateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfVirtualCircuitCreateInput); err == nil {
-		*o = VrfVirtualCircuitCreateInput(varVrfVirtualCircuitCreateInput)
+	err = json.Unmarshal(bytes, &varVrfVirtualCircuitCreateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfVirtualCircuitCreateInput(varVrfVirtualCircuitCreateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/metal/v1/model_vrf_virtual_circuit_update_input.go
+++ b/metal/v1/model_vrf_virtual_circuit_update_input.go
@@ -393,9 +393,13 @@ func (o VrfVirtualCircuitUpdateInput) ToMap() (map[string]interface{}, error) {
 func (o *VrfVirtualCircuitUpdateInput) UnmarshalJSON(bytes []byte) (err error) {
 	varVrfVirtualCircuitUpdateInput := _VrfVirtualCircuitUpdateInput{}
 
-	if err = json.Unmarshal(bytes, &varVrfVirtualCircuitUpdateInput); err == nil {
-		*o = VrfVirtualCircuitUpdateInput(varVrfVirtualCircuitUpdateInput)
+	err = json.Unmarshal(bytes, &varVrfVirtualCircuitUpdateInput)
+
+	if err != nil {
+		return err
 	}
+
+	*o = VrfVirtualCircuitUpdateInput(varVrfVirtualCircuitUpdateInput)
 
 	additionalProperties := make(map[string]interface{})
 

--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -404,9 +404,13 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{#isMap}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
-		*o = {{{classname}}}(var{{{classname}}})
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+
+	if err != nil {
+		return err
 	}
+
+	*o = {{{classname}}}(var{{{classname}}})
 
 	additionalProperties := make(map[string]interface{})
 
@@ -423,9 +427,13 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{^parent}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
-		*o = {{{classname}}}(var{{{classname}}})
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+
+	if err != nil {
+		return err
 	}
+
+	*o = {{{classname}}}(var{{{classname}}})
 
 	additionalProperties := make(map[string]interface{})
 

--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -1,0 +1,450 @@
+// checks if the {{classname}} type satisfies the MappedNullable interface at compile time
+var _ MappedNullable = &{{classname}}{}
+
+// {{classname}} {{{description}}}{{^description}}struct for {{{classname}}}{{/description}}
+type {{classname}} struct {
+{{#parent}}
+{{^isMap}}
+{{^isArray}}
+	{{{parent}}}
+{{/isArray}}
+{{/isMap}}
+{{#isArray}}
+	Items {{{parent}}}
+{{/isArray}}
+{{/parent}}
+{{#vars}}
+{{^-first}}
+{{/-first}}
+{{#description}}
+	// {{{.}}}
+{{/description}}
+{{#deprecated}}
+	// Deprecated
+{{/deprecated}}
+	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+{{/vars}}
+{{#isAdditionalPropertiesTrue}}
+	AdditionalProperties map[string]interface{}
+{{/isAdditionalPropertiesTrue}}
+}
+
+{{#isAdditionalPropertiesTrue}}
+type _{{{classname}}} {{{classname}}}
+
+{{/isAdditionalPropertiesTrue}}
+// New{{classname}} instantiates a new {{classname}} object
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+	this := {{classname}}{}
+{{#allVars}}
+{{#required}}
+	this.{{name}} = {{nameInCamelCase}}
+{{/required}}
+{{^required}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{^isReadOnly}}
+{{#isNullable}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = &{{nameInCamelCase}}
+{{/isNullable}}
+{{/isReadOnly}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/required}}
+{{/allVars}}
+	return &this
+}
+
+// New{{classname}}WithDefaults instantiates a new {{classname}} object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func New{{classname}}WithDefaults() *{{classname}} {
+	this := {{classname}}{}
+{{#vars}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{^isReadOnly}}
+{{#isNullable}}
+{{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+{{/isNullable}}
+{{/isReadOnly}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/vars}}
+	return &this
+}
+
+{{#vars}}
+{{#required}}
+// Get{{name}} returns the {{name}} field value
+{{#isNullable}}
+// If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/isNullable}}
+}
+
+// Set{{name}} sets field value
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set(&v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = v
+{{/isNullable}}
+}
+
+{{/required}}
+{{^required}}
+// Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}.Get()){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return {{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}, true
+{{/isNullable}}
+}
+
+// Has{{name}} returns a boolean if a field has been set.
+func (o *{{classname}}) Has{{name}}() bool {
+	if o != nil && {{^isNullable}}!IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		return true
+	}
+
+	return false
+}
+
+// Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set({{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v
+{{/isNullable}}
+}
+{{#isNullable}}
+{{^vendorExtensions.x-golang-is-container}}
+// Set{{name}}Nil sets the value for {{name}} to be an explicit nil
+func (o *{{classname}}) Set{{name}}Nil() {
+	o.{{name}}.Set(nil)
+}
+
+// Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
+func (o *{{classname}}) Unset{{name}}() {
+	o.{{name}}.Unset()
+}
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+
+{{/required}}
+{{/vars}}
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+	toSerialize,err := o.ToMap()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(toSerialize)
+}
+
+func (o {{classname}}) ToMap() (map[string]interface{}, error) {
+	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
+	{{#parent}}
+	{{^isMap}}
+	{{^isArray}}
+	serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+	if err{{parent}} != nil {
+		return map[string]interface{}{}, err{{parent}}
+	}
+	err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+	if err{{parent}} != nil {
+		return map[string]interface{}{}, err{{parent}}
+	}
+	{{/isArray}}
+	{{/isMap}}
+	{{#isArray}}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	{{/isArray}}
+	{{/parent}}
+	{{#vars}}
+	{{! if argument is nullable, only serialize it if it is set}}
+	{{#isNullable}}
+	{{#vendorExtensions.x-golang-is-container}}
+	{{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+	if o.{{name}} != nil {
+		toSerialize["{{baseName}}"] = o.{{name}}
+	}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{^vendorExtensions.x-golang-is-container}}
+	{{#required}}
+	toSerialize["{{baseName}}"] = o.{{name}}.Get()
+	{{/required}}
+	{{^required}}
+	if o.{{name}}.IsSet() {
+		toSerialize["{{baseName}}"] = o.{{name}}.Get()
+	}
+	{{/required}}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{/isNullable}}
+	{{! if argument is not nullable, don't set it if it is nil}}
+	{{^isNullable}}
+	{{#required}}
+	toSerialize["{{baseName}}"] = o.{{name}}
+	{{/required}}
+	{{^required}}
+	if !IsNil(o.{{name}}) {
+		toSerialize["{{baseName}}"] = o.{{name}}
+	}
+	{{/required}}
+	{{/isNullable}}
+	{{/vars}}
+	{{#isAdditionalPropertiesTrue}}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
+	{{/isAdditionalPropertiesTrue}}
+	return toSerialize, nil
+}
+
+{{#isAdditionalPropertiesTrue}}
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+{{#parent}}
+{{^isMap}}
+	type {{classname}}WithoutEmbeddedStruct struct {
+	{{#vars}}
+	{{^-first}}
+	{{/-first}}
+	{{#description}}
+		// {{{.}}}
+	{{/description}}
+	{{#deprecated}}
+		// Deprecated
+	{{/deprecated}}
+		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{/vars}}
+	}
+
+	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
+	if err == nil {
+		var{{{classname}}} := _{{{classname}}}{}
+		{{#vars}}
+		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
+		{{/vars}}
+		*o = {{{classname}}}(var{{{classname}}})
+	} else {
+		return err
+	}
+
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+	if err == nil {
+		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
+	} else {
+		return err
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+
+		// remove fields from embedded structs
+		reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+		for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+			t := reflect{{{parent}}}.Type().Field(i)
+
+			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+				fieldName := ""
+				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+					fieldName = jsonTag[:commaIdx]
+				} else {
+					fieldName = jsonTag
+				}
+				if fieldName != "AdditionalProperties" {
+					delete(additionalProperties, fieldName)
+				}
+			}
+		}
+
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{#isMap}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+		*o = {{{classname}}}(var{{{classname}}})
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{/parent}}
+{{^parent}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+		*o = {{{classname}}}(var{{{classname}}})
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/parent}}
+}
+
+{{/isAdditionalPropertiesTrue}}
+{{#isArray}}
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+	return json.Unmarshal(bytes, &o.Items)
+}
+
+{{/isArray}}
+{{>nullable_model}}


### PR DESCRIPTION
The Go generator we are using generates code that ignores errors while unmarshalling JSON responses from the API into Go structs.  This means that if the API spec says a field will be an integer but the field in the API response is a string, the Go SDK will return a struct with nil values for all fields instead of returning an error.

This updates the model_simple.mustache template to make the unmarshal function return errors when they happen rather than ignoring them.