### PR TITLE
fix: update spec for plan drive type to match API response

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -30738,7 +30738,7 @@ components:
       enum:
       - HDD
       - SSD
-      - NVME
+      - NVMe
       type: string
     Plan_specs_drives_inner_category:
       enum:

--- a/docs/PlanSpecsDrivesInnerType.md
+++ b/docs/PlanSpecsDrivesInnerType.md
@@ -7,7 +7,7 @@
 
 * `SSD` (value: `"SSD"`)
 
-* `NVME` (value: `"NVME"`)
+* `NVME` (value: `"NVMe"`)
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/metal/v1/model_plan_specs_drives_inner_type.go
+++ b/metal/v1/model_plan_specs_drives_inner_type.go
@@ -23,14 +23,14 @@ type PlanSpecsDrivesInnerType string
 const (
 	PLANSPECSDRIVESINNERTYPE_HDD  PlanSpecsDrivesInnerType = "HDD"
 	PLANSPECSDRIVESINNERTYPE_SSD  PlanSpecsDrivesInnerType = "SSD"
-	PLANSPECSDRIVESINNERTYPE_NVME PlanSpecsDrivesInnerType = "NVME"
+	PLANSPECSDRIVESINNERTYPE_NVME PlanSpecsDrivesInnerType = "NVMe"
 )
 
 // All allowed values of PlanSpecsDrivesInnerType enum
 var AllowedPlanSpecsDrivesInnerTypeEnumValues = []PlanSpecsDrivesInnerType{
 	"HDD",
 	"SSD",
-	"NVME",
+	"NVMe",
 }
 
 func (v *PlanSpecsDrivesInnerType) UnmarshalJSON(src []byte) error {

--- a/patches/spec.fetched.json/20230920-plan-drive-type.patch
+++ b/patches/spec.fetched.json/20230920-plan-drive-type.patch
@@ -1,0 +1,13 @@
+diff --git a/spec/oas3.patched/components/schemas/Plan.yaml b/spec/oas3.patched/components/schemas/Plan.yaml
+index 0b5f1d5..c8cdf6f 100644
+--- a/spec/oas3.patched/components/schemas/Plan.yaml
++++ b/spec/oas3.patched/components/schemas/Plan.yaml
+@@ -97,7 +97,7 @@ properties:
+               enum:
+                 - HDD
+                 - SSD
+-                - NVME
++                - NVMe
+             size:
+               type: string
+               example: 3.84TB

--- a/spec/oas3.patched/components/schemas/Plan.yaml
+++ b/spec/oas3.patched/components/schemas/Plan.yaml
@@ -97,7 +97,7 @@ properties:
               enum:
                 - HDD
                 - SSD
-                - NVME
+                - NVMe
             size:
               type: string
               example: 3.84TB


### PR DESCRIPTION
Relates to #154 (technically a fix, but I want to leave that issue open in hopes of a better solution later)

This updates the enum items for drive types in a plan spec to change `NVME` to `NVMe`.  The original spec has `NVME`, but the API actually uses the value `NVMe`, and the difference in case causes API responses to be invalid according to the spec.

I tried patching in `NVMe` as an additional option, as mentioned in https://github.com/equinix-labs/metal-go/issues/154#issuecomment-1728316194, but that causes the generator to generate invalid code because the constants for `NVMe` and `NVME` are both generated with the same name:

```
metal/v1/model_plan_specs_drives_inner_type.go:27:2: PLANSPECSDRIVESINNERTYPE_NVME redeclared in this block
```

We could patch the spec to remove the enum entirely for this property, but I wanted to keep this change as small as possible.