### PR TITLE
feat: include API messages in errors

### DIFF
--- a/metal/v1/client.go
+++ b/metal/v1/client.go
@@ -767,20 +767,32 @@ func (e GenericOpenAPIError) Model() interface{} {
 	return e.model
 }
 
-// format error message using title and detail when model implements rfc7807
+// format error message using title and detail when model is an instance of
+// the Error component schema or when it implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
 	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	errorModel, ok := v.(*Error)
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
+	if ok {
+		errs := []string{}
+		errs = append(errs, errorModel.GetErrors()...)
+		if errorModel.GetError() != "" {
+			errs = append(errs, errorModel.GetError())
 		}
+		str = strings.Join(errs, ", ")
+	} else {
+		metaValue := reflect.ValueOf(v).Elem()
 
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
+		if metaValue.Kind() == reflect.Struct {
+			field := metaValue.FieldByName("Title")
+			if field != (reflect.Value{}) {
+				str = fmt.Sprintf("%s", field.Interface())
+			}
+
+			field = metaValue.FieldByName("Detail")
+			if field != (reflect.Value{}) {
+				str = fmt.Sprintf("%s (%s)", str, field.Interface())
+			}
 		}
 	}
 

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -733,20 +733,32 @@ func (e GenericOpenAPIError) Model() interface{} {
 	return e.model
 }
 
-// format error message using title and detail when model implements rfc7807
+// format error message using title and detail when model is an instance of
+// the Error component schema or when it implements rfc7807
 func formatErrorMessage(status string, v interface{}) string {
 	str := ""
-	metaValue := reflect.ValueOf(v).Elem()
+	errorModel, ok := v.(*Error)
 
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
+	if ok {
+		errs := []string{}
+		errs = append(errs, errorModel.GetErrors()...)
+		if errorModel.GetError() != "" {
+			errs = append(errs, errorModel.GetError())
 		}
+		str = strings.Join(errs, ", ")
+	} else {
+		metaValue := reflect.ValueOf(v).Elem()
 
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
+		if metaValue.Kind() == reflect.Struct {
+			field := metaValue.FieldByName("Title")
+			if field != (reflect.Value{}) {
+				str = fmt.Sprintf("%s", field.Interface())
+			}
+
+			field = metaValue.FieldByName("Detail")
+			if field != (reflect.Value{}) {
+				str = fmt.Sprintf("%s (%s)", str, field.Interface())
+			}
 		}
 	}
 


### PR DESCRIPTION
This updates the `formatErrorMessage` helper so that, if the API responded with an Error model, the messages from that Error model are appended to the status code & status description.  This makes it easier for users to get visibility into why an API call failed.

I chose to leave the existing code to support rfc7807 messages in place, just in case we ever migrate to that standard.

Fixes #168