### PR TITLE
fix:  avoid nil pointer error when debugging requests with no body

### DIFF
--- a/metal/v1/client.go
+++ b/metal/v1/client.go
@@ -362,14 +362,16 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		}
 
 		dump, err := httputil.DumpRequestOut(request, true)
+
+		if hasAuth {
+			request.Header["X-Auth-Token"] = authToken
+		}
+
 		if err != nil {
 			return nil, err
 		}
 		log.Printf("\n%s\n", string(dump))
 
-		if hasAuth {
-			request.Header["X-Auth-Token"] = authToken
-		}
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)

--- a/metal/v1/client.go
+++ b/metal/v1/client.go
@@ -356,18 +356,20 @@ func parameterToJson(obj interface{}) (string, error) {
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		r := request.Clone(context.TODO())
-		r.Body, _ = request.GetBody()
-		h := r.Header
-		if len(h.Get("X-Auth-Token")) != 0 {
-			h.Set("X-Auth-Token", "**REDACTED**")
+		authToken, hasAuth := request.Header["X-Auth-Token"]
+		if hasAuth {
+			request.Header.Set("X-Auth-Token", "**REDACTED**")
 		}
 
-		dump, err := httputil.DumpRequestOut(r, true)
+		dump, err := httputil.DumpRequestOut(request, true)
 		if err != nil {
 			return nil, err
 		}
 		log.Printf("\n%s\n", string(dump))
+
+		if hasAuth {
+			request.Header["X-Auth-Token"] = authToken
+		}
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -255,14 +255,16 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		}
 
 		dump, err := httputil.DumpRequestOut(request, true)
+
+		if hasAuth {
+			request.Header["X-Auth-Token"] = authToken
+		}
+		
 		if err != nil {
 			return nil, err
 		}
 		log.Printf("\n%s\n", string(dump))
 
-		if hasAuth {
-			request.Header["X-Auth-Token"] = authToken
-		}
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -249,18 +249,20 @@ func parameterToJson(obj interface{}) (string, error) {
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		r := request.Clone(context.TODO())
-		r.Body, _ = request.GetBody()
-		h := r.Header
-		if len(h.Get("X-Auth-Token")) != 0 {
-			h.Set("X-Auth-Token", "**REDACTED**")
+		authToken, hasAuth := request.Header["X-Auth-Token"]
+		if hasAuth {
+			request.Header.Set("X-Auth-Token", "**REDACTED**")
 		}
 
-		dump, err := httputil.DumpRequestOut(r, true)
+		dump, err := httputil.DumpRequestOut(request, true)
 		if err != nil {
 			return nil, err
 		}
 		log.Printf("\n%s\n", string(dump))
+
+		if hasAuth {
+			request.Header["X-Auth-Token"] = authToken
+		}
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)


### PR DESCRIPTION
@cprivitere reported that cluster-api-provider-packet experiences nil pointer errors when debugging is enabled and a request has no body.  This behavior seems to have started in v0.25.1, which introduced automatic auth token redaction in debug output.

In order to redact the auth token without impacting the original request, we were cloning the request object.  In order to clone the request body, we had to call `request.GetBody()`, but that function causes a nil pointer error if the request body is nil.

This updates the auth token redaction code to temporarily overwrite the auth token in the original request, rather than cloning the request & its potentially-nil body.