### PR TITLE
feat: add deprecation comment to go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ validate:
 mod:
 	rm -f go.mod go.sum ${PACKAGE_PREFIX}/${PACKAGE_MAJOR}/go.mod ${PACKAGE_PREFIX}/${PACKAGE_MAJOR}/go.sum
 	go mod init github.com/${GIT_ORG}/${GIT_REPO}
+	printf "// Deprecated: use github.com/equinix/equinix-sdk-go instead.\n%s" "$$(cat go.mod)" > go.mod
 	go mod tidy
 
 test:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/equinix/equinix-sdk-go instead.
 module github.com/equinix-labs/metal-go
 
 go 1.19


### PR DESCRIPTION
Added a comment linking to equinix-sdk-go, based on https://go.dev/ref/mod#go-mod-file-module-deprecation

Since this repo is generated, the go.mod change has to be made via the `make mod` task so it's not removed when the code is generated.